### PR TITLE
Full Julia implementation of specification

### DIFF
--- a/src/julia/README.md
+++ b/src/julia/README.md
@@ -19,7 +19,9 @@ Just type `Pkg.add("JSON")` at the Julia prompt.
 
 ## Minimal reader / writer
 
-The minimal WCON reader is in `Minimal.jl`.  Just `include("Minimal.jl")` and then use
+The minimal WCON reader is in `Minimal.jl`.  If you want to build a lightweight WCON reader/writer
+for your own data, this may be a good place to start.  To use it, just `include("Minimal.jl")` and then
+enter
 
 ```julia
 TrackerCommonsMinimal.read_wcon("my/path/to/my_data.wcon")
@@ -32,3 +34,36 @@ If you have a `WormDataSet`, you can write it out with
 ```julia
 TrackerCommonsMinimal.write_wcon("my/path/to/new_file.wcon")
 ```
+
+## Full-featured reader / writer
+
+### Data I/O
+
+TODO: write examples.
+
+### Data Types
+
+Worm data, including a single ID, plus a time series and x- and y-coordinate values, is
+represented in the `CommonWorm` type.
+
+TODO: finish section
+
+#### A note about Data Frames
+
+Julia contains a _Data Frame_ type, motivated by a similar type in R, that consists of
+tabular data with named column headers.  Data frames are commonly used in data analysis
+and statistics, so it would seem that they would be a natural fit for worm tracking data.
+
+However, tracking data is not necessarily a convenient rectangular shape: worms may be
+tracked for different periods of time, and within one worm, some data may be static (which side is ventral),
+some may be a scalar for each time point (centroid), and other data may be vector valued (x coordinates of
+spine).  Forcing the data into tabular form could thus be inefficient and require the user to
+deal with frequent missing data.
+
+Thus, the Tracker Commons implementation imports the data in custom structures.  Users are
+encouraged to convert this to Data Frames in those cases where it suits their analysis.
+
+### Unit Conversions
+
+TODO: finish section
+

--- a/src/julia/src/CommonWorm.jl
+++ b/src/julia/src/CommonWorm.jl
@@ -8,24 +8,7 @@ type CommonWorm
     custom :: Dict{AbstractString, Any}
 end
 
-#function can_merge_worms(a :: CommonWorm, b :: CommonWorm)
-#    if (a.id != b.id) false
-#    elseif (length(a.t) == 0 || length(b.t) == 0 || a[end] < b[1] || b[end] < a[1]) true
-#    else false
-#    end
-#end
-#
-# THIS FUNCTION IS BROKEN--merging custom fields by throwing away one is almost surely wrong!
-#function merge_worms(a :: CommonWorm, b :: CommonWorm)
-#    assert(a.id == b.id)
-#    if (length(a.t) == 0) CommonWorm(a.id, b.t, b.x, b.y, b.cx, b.cy, merge(a.custom,b.custom))
-#    elseif (length(b.t) == 0) CommonWorm(a.id, a.t, a.x, a.y, a.cx, a.cy, merge(b.custom,a.custom))
-#    elseif (a[end] < b[1]) CommonWorm(a.id, [a.t;b.t], [a.x;b.x], [a.y;b.y], [a.cx;b.cx], [a.cy;b.cy], merge(a.custom,b.custom))
-#    elseif (b[end] < a[1]) CommonWorm(a.id, [b.t;a.t], [b.x;a.x], [b.y;a.y], [b.cx;a.cx], [b.cy;a.cy], merge(b.custom;a.custom))
-#    else error("Cannot merge overlapping data sets")
-#end
-
-function common_worm_as_dict(cw :: CommonWorm)
+function convert_for_json(cw :: CommonWorm)
     d = Dict{AbstractString, Any}("id" => cw.id, "t" => cw.t, "x" => cw.x, "y" => cw.y)
     if (length(cx) > 0)
         d["cx"] = cw.cx
@@ -37,4 +20,151 @@ function common_worm_as_dict(cw :: CommonWorm)
         d = merge(custom,d)   # In case of duplicate keys, 2nd arg's keys win
     end
     d
+end
+
+function parsed_json_to_worm(d :: Dict{AbstractString, Any})
+    result :: Union{AbstractString, CommonWorm} = "Failed to parse worm with no ID"
+    if !haskey(d, "id")
+        return result
+    end
+    id = begin
+        temp = d["id"]
+        if isa(temp, Number)
+            string(temp)
+        elseif isa(temp, AbstractString)
+            convert(AbstractString, temp)
+        else
+            result = "Worm ID should be a number or a string"
+            return result
+            ""
+        end
+    end
+    if !haskey(d, "t")
+        result = string("Failed to parse worm ", id, ": no t")
+        return result
+    end
+    t = begin
+        temp = d["t"]
+        if isa(temp, Number)
+            [convert(Float64, temp)]
+        elseif isa(temp, Array{Float64, 1})
+            convert(Array{Float64, 1}, temp)
+        else
+            result = string("Failed to parse worm ", id, ": t is not a number or array of numbers")
+            return result
+            [0.0]
+        end
+    end
+    if !haskey(d, "x")
+        result = string("Failed to parse worm ", id, " at ", t[1], ": missing x")
+        return result
+    end
+    if !haskey(d, "y")
+        result = string("Failed to parse worm ", id, " at ", t[1], ": missing y")
+        return result
+    end
+    x = fill(Array{Float64, 1}(), length(t))
+    y = fill(Array{Float64, 1}(), length(t))
+    for (q, q0, qs) in [(x, d["x"], "x"), (y, d["y"], "y")]
+        if isa(q0, Array{Float64, 1})
+            if length(q) == 1 q[1] = q0
+            elseif length(q) == length(q0)
+                for i in 1:length(q0)
+                    q[i] = [q0[i]]
+                end
+            else
+                result = string("Failed to parse worm ", id, " at ", t[1], ": wrong size for ", qs)
+                return result
+            end
+        elseif isa(q0, Number)
+            if length(q) == 1 q[1]= [convert(Float64, q0)]
+            else
+                result = string("Failed to parse worm ", id, " at ", t[1], ": wrong size for ", qs)
+                return result
+            end
+        elseif isa(q0, Array)
+            if length(q0) != length(x)
+                result = string("Failed to parse worm ", id, " at ", t[1], ": wrong size for ", qs)
+                return result
+            end
+            for i in 1:length(q0)
+                q0i = q0[i]
+                if isa(q0i, Array{Float64, 1})
+                    q[i] = convert(Array{Float64, 1}, q0i)
+                elseif isa(q0i, Number)
+                    q[i] = [convert(Float64, q0i)]
+                else
+                    result = string("Failed to parse worm ", id, " at ", t[1], ": ", qs, " index ", i, " should be a number or array of numbers")
+                end
+            end
+        else
+            result = string("Failed to parse worm ", id, " at ", t[1], ": ", qs, " should be an array of numbers or an array of arrays of numbers")
+            return result
+        end
+    end
+    for i in 1:length(x)
+        if length(x[i]) != length(y[i])
+            result = string("Failed to parse worm ", id, " lengths of x and y spines do not agree at t = ", t[i])
+            return result
+        end
+    end
+    cx = haskey(d,"cx") ? fill(NaN, length(t)) : Array{Float64, 1}()
+    cy = haskey(d,"cy") ? fill(NaN, length(t)) : Array{Float64, 1}()
+    for (q, c, s) in [(x, cx, "x"), (y, cy, "y")]
+        kc = string("c",s)
+        ko = string("o",s)
+        if haskey(d, kc)
+            dc = d[kc]
+            if isa(dc, Number)
+                cc = convert(Float64, dc)
+                for i in 1:length(c) c[i] = cc end
+            else
+                cc = convert(Array{Float64, 1}, dc)
+                if length(cc) == length(c)
+                    for i in 1:length(c) c[i] = cc[i] end
+                else
+                    result = string("Failed to parse worm ", id, " at ", t[1], ": wrong size for ",kc)
+                    return result
+                end
+            end
+        end
+        if haskey(d, kc) || haskey(d, ko)
+            o = haskey(d, ko) ? d[ko] : d[kc]
+            if isa(o, Number)
+                oo = convert(Float64, o)
+                for i in 1:length(q)
+                    for j in 1:length(q[i])
+                        q[i][j] = q[i][j] + oo
+                    end
+                end
+                if haskey(d, ko) && haskey(d, kc)
+                    for i in 1:length(c)
+                        c[i] = c[i] + oo
+                    end
+                end
+            elseif isa(o, Array{Float64, 1})
+                oo = convert(Array{Float64, 1}, o)
+                if length(oo) != length(q)
+                    result = string("Failed to parse worm ", id, " at ", t[1], ": wrong size for ", haskey(d, ko) ? ko : kc)
+                    return result
+                end
+                for i in 1:length(q)
+                    oi = oo[i]
+                    for j in 1:length(q[i])
+                        q[i][j] = q[i][j] + oi
+                    end
+                end
+                if haskey(d, ko) && haskey(d, kc)
+                    for i in 1:length(c)
+                        c[i] = c[i] + oo[i]
+                    end
+                end
+            else
+                result = string("Failed to parse worm ", id, " at ", t[1], ": need number or array of numbers for ", haskey(d, ko) ? ko : kc)
+                return result
+            end
+        end
+    end
+    result = CommonWorm(id, t, x, y, cx, cy, extract_custom(d))
+    return result
 end

--- a/src/julia/src/CommonWorm.jl
+++ b/src/julia/src/CommonWorm.jl
@@ -1,0 +1,42 @@
+module TrackerCommons
+
+type CommonWorm
+    id :: AbstractString
+    t  :: Array{Float64, 1}
+    x  :: Array{Array{Float64, 1}, 1}
+    y  :: Array{Array{Float64, 1}, 1}
+    cx :: Array{Float64, 1}
+    cy :: Array{Float64, 1}
+    custom :: Dict{AbstractString, Any}
+end
+
+#function can_merge_worms(a :: CommonWorm, b :: CommonWorm)
+#    if (a.id != b.id) false
+#    elseif (length(a.t) == 0 || length(b.t) == 0 || a[end] < b[1] || b[end] < a[1]) true
+#    else false
+#    end
+#end
+#
+# THIS FUNCTION IS BROKEN--merging custom fields by throwing away one is almost surely wrong!
+#function merge_worms(a :: CommonWorm, b :: CommonWorm)
+#    assert(a.id == b.id)
+#    if (length(a.t) == 0) CommonWorm(a.id, b.t, b.x, b.y, b.cx, b.cy, merge(a.custom,b.custom))
+#    elseif (length(b.t) == 0) CommonWorm(a.id, a.t, a.x, a.y, a.cx, a.cy, merge(b.custom,a.custom))
+#    elseif (a[end] < b[1]) CommonWorm(a.id, [a.t;b.t], [a.x;b.x], [a.y;b.y], [a.cx;b.cx], [a.cy;b.cy], merge(a.custom,b.custom))
+#    elseif (b[end] < a[1]) CommonWorm(a.id, [b.t;a.t], [b.x;a.x], [b.y;a.y], [b.cx;a.cx], [b.cy;a.cy], merge(b.custom;a.custom))
+#    else error("Cannot merge overlapping data sets")
+#end
+
+function common_worm_as_dict(cw :: CommonWorm)
+    d = Dict{AbstractString, Any}("id" => cw.id, "t" => cw.t, "x" => cw.x, "y" => cw.y)
+    if (length(cx) > 0)
+        d["cx"] = cw.cx
+    end
+    if (length(cy) > 0)
+        d["cy"] = cw.cy
+    end
+    if (length(custom) > 0)
+        d = merge(custom,d)   # In case of duplicate keys, 2nd arg's keys win
+    end
+    d
+end

--- a/src/julia/src/CommonWorm.jl
+++ b/src/julia/src/CommonWorm.jl
@@ -8,6 +8,10 @@ type CommonWorm
     custom :: Dict{AbstractString, Any}
 end
 
+function empty_worm()
+    CommonWorm("", [], [], [], [], [], Dict())
+end
+
 function convert_for_json(cw :: CommonWorm)
     d = Dict{AbstractString, Any}("id" => cw.id, "t" => cw.t, "x" => cw.x, "y" => cw.y)
     if (length(cx) > 0)

--- a/src/julia/src/CommonWorm.jl
+++ b/src/julia/src/CommonWorm.jl
@@ -1,3 +1,10 @@
+## This file is part of Open Worm's Tracker Commons project and is distributed under the MIT license.
+## Contents copyright (c) 2016 by Rex Kerr, Calico Life Sciences, and Open Worm.
+
+###############################################################
+# Get basic worm data into / out of a JSON-derived dictionary #
+###############################################################
+
 type CommonWorm
     id :: AbstractString
     t  :: Array{Float64, 1}

--- a/src/julia/src/CommonWorm.jl
+++ b/src/julia/src/CommonWorm.jl
@@ -1,5 +1,3 @@
-module TrackerCommons
-
 type CommonWorm
     id :: AbstractString
     t  :: Array{Float64, 1}

--- a/src/julia/src/CommonWorm.jl
+++ b/src/julia/src/CommonWorm.jl
@@ -14,13 +14,13 @@ end
 
 function convert_for_json(cw :: CommonWorm)
     d = Dict{AbstractString, Any}("id" => cw.id, "t" => cw.t, "x" => cw.x, "y" => cw.y)
-    if (length(cx) > 0)
+    if (length(cw.cx) > 0)
         d["cx"] = cw.cx
     end
-    if (length(cy) > 0)
+    if (length(cw.cy) > 0)
         d["cy"] = cw.cy
     end
-    if (length(custom) > 0)
+    if (length(cw.custom) > 0)
         d = merge(custom,d)   # In case of duplicate keys, 2nd arg's keys win
     end
     d
@@ -87,7 +87,7 @@ function parsed_json_to_worm(d :: Dict{AbstractString, Any})
                 return result
             end
         elseif isa(q0, Array)
-            if length(q0) != length(x)
+            if length(q0) != length(t)
                 result = string("Failed to parse worm ", id, " at ", t[1], ": wrong size for ", qs)
                 return result
             end

--- a/src/julia/src/DataSet.jl
+++ b/src/julia/src/DataSet.jl
@@ -1,0 +1,150 @@
+type DataSet
+    conversions :: KnownUnits
+    meta :: MetaData
+    data :: Array{CommonWorm, 1}
+    my_filename :: AbstractString
+    next_filename :: Nullable{AbstractString}
+    prev_filename :: Nullable{AbstractString}
+    files_custom :: Dict{AbstractString, Any}
+    custom :: Dict{AbstractString, Any}
+end
+
+function empty_dataset()
+    DataSet(
+        minimal_known_units(),
+        empty_metadata(),
+        [],
+        "",
+        Nullable{AbstractString}(),
+        Nullable{AbstractString}(),
+        no_custom(),
+        no_custom()
+    )
+end
+
+function convert_for_json(ds :: DataSet)
+    result :: Dict{AbstractString, Any} = Dict{AbstractString, Any}()
+    if !(ds.next_filename.isnull && ds.prev_filename.isnull && length(ds.files_custom) == 0)
+        fs = Dict{AbstractString, Any}
+        fs["this"] = ds.my_filename
+        if !ds.next_filename.isnull fs["next"] = ds.next_filename end
+        if !ds.prev_filename.isnull fs["prev"] = ds.prev_filename end
+        if length(ds.files_custom) > 0
+            for (k,v) in ds.files_custom fs[k] = v end
+        end
+        result["files"] = fs
+    end
+    result["units"] = convert_for_json(ds.conversions)
+    md = convert_for_json(ds.meta)
+    if length(md) > 0 result["metadata"] = md end
+    result["data"] = map(x -> convert_for_json(x), ds.data)
+    for (k,v) in ds.custom
+        result[k] = v
+    end
+    return result
+end
+
+function parsed_json_to_dataset(j :: Dict{AbstractString, Any}, fullname :: AbstractString)
+    result :: Union{AbstractString, DataSet} = ""
+    u = begin
+            if !haskey(j, "units")
+                result = "Invalid WCON file: no units"
+                return result
+            elseif !isa(j["units"], Dict{AbstractString, Any})
+                result = "Failed to parse WCON units: units must be a JSON object"
+                return result
+            end
+            ux = parsed_json_to_units(j["units"])
+            if isa(ux, AbstractString)
+                result = string("Failed to parse WCON units.  ", convert(AbstractString, u))
+                return result
+            end
+            convert(KnownUnits, ux)
+        end
+    m = if !haskey(j, "metadata") empty_metadata()
+        else
+            if !isa(j["metadata"], Dict{AbstractString, Any})
+                result = string("Failed to parse WCON metadata: metadata must be a JSON object")
+                return result
+            end
+            mx = parsed_json_to_metadata(j["metadata"])
+            if isa(mx, AbstractString)
+                result = string("Failed to parse WCON metadata.  ", convert(AbstractString, m))
+                return result
+            end
+            convert(MetaData, mx)
+        end
+    d = begin
+            if !haskey(j, "data")
+                result = "Invalid WCON file: no data"
+                return result
+            elseif !isa(j["data"], Array) && !isa(j["data"], Dict{AbstractString, Any})
+                result = "Invalid WCON file: data must be an array of JSON objects"
+                return result
+            end
+            ds :: Array = isa(j["data"], Array) ? j["data"] : [j["data"]]
+            ans = fill(empty_worm(), length(ds))
+            for i in 1:length(ds)
+                di = ds[i]
+                if !isa(di, Dict{AbstractString, Any})
+                    result = string("Failed to parse WCON data.  Element ", i, " is not a JSON object.")
+                    return result
+                end
+                ai = parsed_json_to_worm(di)
+                if isa(ai, AbstractString)
+                    result = string("Failed to parse WCON data, element ", i, ".  ", convert(AbstractString, ai))
+                    return result
+                end
+                ans[i] = convert(CommonWorm, ai)
+            end
+            ans
+        end
+    c = extract_custom(j)
+    all = DataSet(u, m, d, fullname, Nullable{AbstractString}(), Nullable{AbstractString}(), no_custom(), c)
+    if haskey(j, "files")
+        if ~isa(j["files"], Dict{AbstractString, Any})
+            result = "Failed to parse WCON files entry: it is not a JSON object"
+            return result
+        end
+        f = convert(Dict{AbstractString, Any}, j["files"])
+        if !haskey(f, "this")
+            result = "Failed to parse WCON files entry.  No 'this' key present."
+            return result
+        end
+        if ~isa(f["this"], AbstractString)
+            result = "Failed to parse WCON files entry.  'this' filename is not a string."
+            return result
+        end
+        myname = convert(AbstractString, f["this"])
+        i = rsearchindex(fullname, myname)
+        if i > 0 && i+5 > length(fullname) && (endswith(lowercase(fullname), ".wcon") || endswith(lowercase(fullname), ".json"))
+            i = rsearchindex(fullname, myname, length(fullname)-5+length(myname))
+        end
+        if i == 0
+            result = string("Failed to parse WCON files entry.  Could not find 'this' name fragment ", myname, " within ", fullname)
+            return result
+        end
+        fc = extract_custom(f)
+        if length(fc) > 0 all.files_custom = fc end
+        if haskey(f, "next")
+            n = f["next"]
+            if !isa(n, AbstractString) && !(isa(n, Array) && isa(n[1], AbstractString))
+                result = "Failed to parse WCON files entry: 'next' should be a string or array of strings"
+                return result
+            end
+            nextname = convert(AbstractString, isa(n, AbstractString) ? n : n[1])
+            all.next_filename = Nullable(string(fullname[1:(i-1)], nextname, fullname[(i+length(myname)):end]))
+        end
+        if haskey(f, "prev")
+            p = f["prev"]
+            if !isa(p, AbstractString) && !(isa(p, Array) && isa(p[1], AbstractString))
+                result = "Failed to parse WCON files entry: 'prev' should be a string or array of strings"
+                return result
+            end
+            prevname = convert(AbstractString, isa(p, AbstractString) ? p : p[1])
+            all.prev_filename = Nullable(string(fullname[1:(i-1)], prevname, fullname[(i+length(myname)):end]))
+        end
+    end
+    result = all
+    return result
+end

--- a/src/julia/src/DataSet.jl
+++ b/src/julia/src/DataSet.jl
@@ -1,3 +1,10 @@
+## This file is part of Open Worm's Tracker Commons project and is distributed under the MIT license.
+## Contents copyright (c) 2016 by Rex Kerr, Calico Life Sciences, and Open Worm.
+
+############################################
+# DataSet representing an entire WCON file #
+############################################
+
 type DataSet
     conversions :: KnownUnits
     meta :: MetaData

--- a/src/julia/src/MetaData.jl
+++ b/src/julia/src/MetaData.jl
@@ -1,4 +1,3 @@
-package TrackerCommons
 
 type Laboratory
     pi :: AbstractString
@@ -9,8 +8,9 @@ end
 
 type Arena
     kind :: AbstractString
-    diameter :: Float64
-    other_diameter :: Nullable{Float64}
+    diameterA :: Float64
+    diameterB :: Float64
+    orientation :: AbstractString
     custom :: Dict{AbstractString, Any}
 end
 
@@ -21,21 +21,245 @@ type Software
     custom :: Dict{AbstractString, Any}
 end
 
-
 type MetaData
     lab :: Nullable{Laboratory}
-    who :: Nullable{AbstractString}
-    timestamp :: Union{AbstractString, ???}
-    temperature :: Nullable{Float64}
-    humidity :: Nullable{Float64}
+    who :: AbstractString
+    timestamp :: Nullable{DateTime}
+    temperature :: Float64
+    humidity :: Float64
     arena :: Nullable{Arena}
     food :: AbstractString
     media :: AbstractString
     sex :: AbstractString
-    stage :: Nullable{???}
+    stage :: AbstractString
+    age :: Nullable{Dates.Millisecond}
     strain :: AbstractString
     protocol :: Array{AbstractString, 1}
-    software :: Nullable{Software}
+    software :: Array{Software, 1}
     settings :: Nullable{Any}
     custom :: Dict{AbstractString, Any}
+end
+
+function no_custom()
+    return Dict{AbstractString, Any}()
+end
+
+function empty_laboratory()
+    return Laboratory("", "", "", no_custom())
+end
+
+function empty_arena()
+    return Arena("", NaN, NaN, "", no_custom())
+end
+
+function empty_software()
+    return Software("", "", Set{AbstractString}(), no_custom())
+end
+
+function empty_metadata()
+    return MetaData(Nullable{Laboratory}(), "", Nullable{DateTime}(), NaN, NaN, Nullable{Arena}(), "", "", "", "", Nullable{Dates.Millisecond}(), "", [], [], Nullable{Any}(), no_custom())
+end
+
+function convert_for_json(l :: Laboratory)
+    m = Dict{AbstractString, Any}()
+    if length(l.pi) > 0 m["PI"] = l.pi end
+    if length(l.name) > 0 m["name"]= l.name end
+    if length(l.location) > 0 m["location"] = l.location end
+    if length(l.custom) > 0 m["custom"] = l.custom end
+    return m
+end
+
+function convert_for_json(a :: Arena)
+    m = Dict{AbstractString, Any}()
+    if length(a.kind) > 0 m["kind"] = a.kind end
+    if (!isnan(a.diameterA))
+        if (!isnan(a.diameterB)) m["size"] = [a.diameterA; a.diameterB]
+        else m["size"] = a.diameterA
+        end
+    end
+    if length(a.orientation) > 0 m["orientation"] = a.orientation end
+    if length(a.custom) > 0 m["custom"] = l.custom end
+    return m
+end
+
+function convert_for_json(s :: Software)
+    m = Dict{AbstractString, Any}()
+    if length(s.name) > 0 m["name"] = s.name end
+    if length(s.version) > 0 m["version"] = s.version end
+    if length(s.featureID) > 0 m["featureID"] = collect(s.featureID) end
+    if length(s.custom) > 0 m["custom"] = s.custom end
+    return m
+end
+
+function convert_for_json(m :: MetaData)
+    d = Dict{AbstractString, Any}()
+    if !m.lab.isnull
+        ld = convert_for_json(get(m.lab))
+        if length(ld) > 0 d["lab"] = ld end
+    end
+    if length(m.who) > 0 d["who"] = m.who end
+    if !m.timestamp.isnull d["timestamp"] = string(get(m.timestamp)) end
+    if !isnan(m.temperature) d["temperature"] = m.temperature end
+    if !isnan(m.humidity) d["humidity"] = m.humidity end
+    if !m.arena.isnull
+        la = convert_for_json(get(m.arena))
+        if length(la) > 0 d["arena"] = la end
+    end
+    if length(m.food) > 0 d["food"] = m.food end
+    if length(m.media) > 0 d["media"] = m.media end
+    if length(m.sex) > 0 d["sex"] = m.sex end
+    if length(m.stage) > 0 d["stage"] = m.stage end
+    if length(m.protocol) > 0 d["protocol"] = m.protocol end
+    nzsw = filter(x -> length(x) > 0, map(x -> convert_for_json(x), m.software))
+    if length(nzsw) > 0
+        if length(nzsw) == 1 d["software"] = nzsw[1]
+        else d["software"] = nzsw
+        end
+    end
+    if !m.settings.isnull d["settings"] = get(m.settings) end
+    if length(m.custom) > 0 d["custom"] = m.custom end
+    return d
+end
+
+function error_accum(err :: AbstractString, msg :: AbstractString)
+    result :: AbstractString =
+        if length(err) > 0 string(err, "; ", msg)
+        else msg
+        end
+    return result
+end
+
+function error_if_not_string(a :: Any, err :: AbstractString, msg :: AbstractString)
+    result :: AbstractString = err
+    if !(typeof(a) <: AbstractString) result = error_accum(err, msg) end
+    return result
+end
+
+function empty_if_not_string(a :: Any)
+    if typeof(a) <: AbstractString convert(AbstractString, a) else "" end
+end
+
+function parsed_json_to_laboratory(m :: Dict{AbstractString, Any})
+    result :: Union{Laboratory, AbstractString} = ""
+    err :: AbstractString = ""
+    keys = ["PI", "name", "location"]  # REALLY important to keep these in the same order as Laboratory struct!
+    values = ["", "", ""]
+    for i in 1:length(keys)
+        values[i] = get(m, keys[i], "")
+        err = error_if_not_string(values[i], err, string("Laboratory ", keys[i], " should be a string"))
+    end
+    result =
+        if length(err) > 0 err
+        else Laboratory(
+                values[1], values[2], values[3],
+                Dict(filter(kv -> !(first(kv) in keys), collect(m)))
+            )
+        end
+    return result
+end
+
+function parsed_json_to_arena(m :: Dict{AbstractString, Any})
+    result :: Union{Arena, AbstractString} = ""
+    err :: AbstractString = ""
+    keys = ["type", "size", "orientation"]
+    kind = get(m, keys[1], "")
+    err = error_if_not_string(kind, err, string("Arena ", keys[1], " should be a string"))
+    diam = make_dbl_array(get(m, keys[2], Array{Float64}()))
+    if length(diam) == 1
+        if !(typeof(diam[1]) <: Number) err = error_accum(err, string("Arena ", keys[2], " should be numeric")) end
+    elseif length(diam) == 2
+        if (!diam[1] <: Number && diam[2] <: Number) err = error_accum(err, string("Arena ", keys[2], " should have only numeric entries")) end
+    elseif length(diam) > 2
+        err = error_accum(err, string("Arena ", keys[2], " size should have at most two dimensions"))
+    end
+    orient = get(m,keys[3], "")
+    err = error_if_not_string(orient, err, string("Arena ", keys[3], " should be a string"))
+    result =
+        if length(err) > 0 err
+        else Arena(
+            kind,
+            if length(diam) > 0 diam[1] else NaN end,
+            if length(diam) > 1 diam[2] else NaN end,
+            orient,
+            Dict(filter(kv -> !(first(kv) in keys), collect(m)))
+        )
+        end
+    return result
+end
+
+function parsed_json_to_software(m :: Dict{AbstractString, Any})
+    result :: Union{Software, AbstractString} = ""
+    err :: AbstractString = ""
+    keys = ["name", "version", "featureID"]
+    name = get(m, "name", "")
+    err = error_if_not_string(name, err, string("Software ", keys[1], " should be a string"))
+    version = get(m, "version", "")
+    err = error_if_not_string(name, err, string("Software ", keys[2], " should be a string"))
+    fid = get(m, "featureID", "")
+    featureID :: Set{AbstractString} = Set{AbstractString}()
+    if (typeof(fid) <: AbstractString)
+        str = convert(AbstractString, fid)
+        if length(str) > 0 featureID = Set(str) end
+    elseif typeof(fid) <: Array
+        sid = convert(Array, fid)
+        allstring = true
+        for s in sid
+            if !(typeof(s) <: AbstractString) allstring = false end
+        end
+        if !allstring err = error_accum(err, "Software featureIDs should all be strings")
+        else
+            ids = Set{AbstractString}(map(x -> convert(AbstractString,x), sid))
+            if length(ids) < length(sid) err = error_accum(err, "Sofware should not have duplicate featureIDs")
+            else featureID = ids
+            end
+        end
+    else err = error_accum(err, "Software featureID should be a string or array of strings")
+    end
+    result =
+        if length(err) > 0 err
+        else Software(
+            name, version, featureID,
+            Dict(filter(kv -> !(first(kv) in keys), collect(m)))
+        )
+        end
+    return result
+end
+
+function error_if_not_type{T}(a :: Union{T, AbstractString}, err :: AbstractString)
+    result :: AbstractString =
+        if typeof(a) <: T err
+        elseif length(err) > 0 string(err, "; ", convert(AbstractString, a))
+        else convert(AbstractString, a)
+        end
+    return result
+end
+
+function null_if_not_type{T}(tpe :: DataType{T}, a :: Union{T, AbstractString})
+    result :: Nullable{T} =
+        if typeof(a) <: tpe Nullable(convert(tpe, a)) else Nullable{T}() end
+    return result
+end
+
+function parsed_json_to_metadata(d :: Dict{AbstractString, Any})
+    result :: Union{MetaData, AbstractString} = ""
+    err :: AbstractString = ""
+    keys = [
+        "lab", "who", "timestamp", "temperature", "humidity",
+        "arena", "food", "media", "sex", "stage",
+        "age", "strain", "protocol", "software", "settings"
+    ]
+    onestring = [
+        false, false, false, false, false,
+        false, true, true, true, true,
+        false, true, false, false, false
+    ]
+    strings = fill("", length(keys))
+    for i in 1:length(keys)
+        if onestring[i]
+            s = get(d, keys[i], "")
+            strings[i] = empty_if_not_string(s)
+            err = error_if_not_string(err, string("MetaData ", keys[i], " should be a string"))
+        end
+    end
+    return result
 end

--- a/src/julia/src/MetaData.jl
+++ b/src/julia/src/MetaData.jl
@@ -104,9 +104,7 @@ function convert_for_json(a :: Arena)
     m = Dict{AbstractString, Any}()
     if length(a.kind) > 0 m["kind"] = a.kind end
     if (!isnan(a.diameterA))
-        if (!isnan(a.diameterB)) m["size"] = [a.diameterA; a.diameterB]
-        else m["size"] = a.diameterA
-        end
+        m["size"] = !isnan(a.diameterB) ? [a.diameterA; a.diameterB] : a.diameterA
     end
     if length(a.orientation) > 0 m["orientation"] = a.orientation end
     if length(a.custom) > 0 m["custom"] = l.custom end
@@ -144,9 +142,7 @@ function convert_for_json(m :: MetaData)
     if length(m.protocol) > 0 d["protocol"] = m.protocol end
     nzsw = filter(x -> length(x) > 0, map(x -> convert_for_json(x), m.software))
     if length(nzsw) > 0
-        if length(nzsw) == 1 d["software"] = nzsw[1]
-        else d["software"] = nzsw
-        end
+        d["software"] = length(nzsw) == 1 ? nzsw[1] : nzsw
     end
     if !m.settings.isnull d["settings"] = get(m.settings) end
     if length(m.custom) > 0 d["custom"] = m.custom end
@@ -154,10 +150,7 @@ function convert_for_json(m :: MetaData)
 end
 
 function error_accum(err :: AbstractString, msg :: AbstractString)
-    result :: AbstractString =
-        if length(err) > 0 string(err, "; ", msg)
-        else msg
-        end
+    result :: AbstractString = length(err) > 0 ? string(err, "; ", msg) : msg
     return result
 end
 
@@ -168,7 +161,7 @@ function error_if_not_string(a :: Any, err :: AbstractString, msg :: AbstractStr
 end
 
 function empty_if_not_string(a :: Any)
-    if isa(a, AbstractString) convert(AbstractString, a) else "" end
+    isa(a, AbstractString) ? convert(AbstractString, a) : ""
 end
 
 function parsed_json_to_laboratory(m :: Dict{AbstractString, Any})
@@ -210,8 +203,8 @@ function parsed_json_to_arena(m :: Dict{AbstractString, Any})
         if length(err) > 0 err
         else Arena(
             kind,
-            if length(diam) > 0 diam[1] else NaN end,
-            if length(diam) > 1 diam[2] else NaN end,
+            length(diam) > 0 ? diam[1] : NaN,
+            length(diam) > 1 ? diam[2] : NaN,
             orient,
             Dict(filter(kv -> !(first(kv) in keys), collect(m)))
         )

--- a/src/julia/src/MetaData.jl
+++ b/src/julia/src/MetaData.jl
@@ -1,0 +1,47 @@
+package TrackerCommons
+
+type Laboratory
+    pi :: AbstractString
+    name :: AbstractString
+    location :: AbstractString
+    custom :: Dict{AbstractString, Any}
+end
+
+type Temperature
+    cultivation :: Float64
+    experimental :: Float64
+    custom :: Dict{AbstractString, Any}
+end
+
+type Arena
+    kind :: AbstractString
+    diameter :: Float64
+    other_diameter :: Nullable{Float64}
+    custom :: Dict{AbstractString, Any}
+end
+
+type Software
+    name :: AbstractString
+    version :: AbstractString
+    featureID :: Set{AbstractString}
+    custom :: Dict{AbstractString, Any}
+end
+
+
+type MetaData
+    lab :: Nullable{Laboratory}
+    who :: Nullable{AbstractString}
+    timestamp :: Union{AbstractString, ???}
+    temperature :: Nullable{Temperature}
+    humidity :: Nullable{Float64}
+    arena :: Nullable{Arena}
+    food :: AbstractString
+    media :: AbstractString
+    sex :: AbstractString
+    stage :: Nullable{???}
+    strain :: AbstractString
+    protocol :: Array{AbstractString, 1}
+    software :: Nullable{Software}
+    settings :: Nullable{Any}
+    custom :: Dict{AbstractString, Any}
+end

--- a/src/julia/src/MetaData.jl
+++ b/src/julia/src/MetaData.jl
@@ -1,3 +1,10 @@
+## This file is part of Open Worm's Tracker Commons project and is distributed under the MIT license.
+## Contents copyright (c) 2016 by Rex Kerr, Calico Life Sciences, and Open Worm.
+
+###########################################################
+# Structures for recommended metadata in WCON file format #
+###########################################################
+
 import Base.==
 import Base.isequal
 

--- a/src/julia/src/MetaData.jl
+++ b/src/julia/src/MetaData.jl
@@ -175,10 +175,7 @@ function parsed_json_to_laboratory(m :: Dict{AbstractString, Any})
     end
     result =
         if length(err) > 0 err
-        else Laboratory(
-                values[1], values[2], values[3],
-                Dict(filter(kv -> !(first(kv) in keys), collect(m)))
-            )
+        else Laboratory(values[1], values[2], values[3], extract_custom(m))
         end
     return result
 end
@@ -206,7 +203,7 @@ function parsed_json_to_arena(m :: Dict{AbstractString, Any})
             length(diam) > 0 ? diam[1] : NaN,
             length(diam) > 1 ? diam[2] : NaN,
             orient,
-            Dict(filter(kv -> !(first(kv) in keys), collect(m)))
+            extract_custom(m)
         )
         end
     return result
@@ -242,10 +239,7 @@ function parsed_json_to_software(m :: Dict{AbstractString, Any})
     end
     result =
         if length(err) > 0 err
-        else Software(
-            name, version, featureID,
-            Dict(filter(kv -> !(first(kv) in keys), collect(m)))
-        )
+        else Software(name, version, featureID, extract_custom(m))
         end
     return result
 end
@@ -396,7 +390,7 @@ function parsed_json_to_metadata(d :: Dict{AbstractString, Any})
         laboratory, vstrings[2], stamp, numbers[4], numbers[5],
         arena, strings[7], strings[8], strings[9], strings[10],
         numbers[11], strings[12], vstrings[13], softwares, settings,
-        Dict(filter(kv -> !(first(kv) in keys), collect(d)))
+        extract_custom(d)
     )
     end
     return result

--- a/src/julia/src/MetaData.jl
+++ b/src/julia/src/MetaData.jl
@@ -7,12 +7,6 @@ type Laboratory
     custom :: Dict{AbstractString, Any}
 end
 
-type Temperature
-    cultivation :: Float64
-    experimental :: Float64
-    custom :: Dict{AbstractString, Any}
-end
-
 type Arena
     kind :: AbstractString
     diameter :: Float64
@@ -32,7 +26,7 @@ type MetaData
     lab :: Nullable{Laboratory}
     who :: Nullable{AbstractString}
     timestamp :: Union{AbstractString, ???}
-    temperature :: Nullable{Temperature}
+    temperature :: Nullable{Float64}
     humidity :: Nullable{Float64}
     arena :: Nullable{Arena}
     food :: AbstractString

--- a/src/julia/src/Minimal.jl
+++ b/src/julia/src/Minimal.jl
@@ -1,3 +1,10 @@
+## This file is part of Open Worm's Tracker Commons project and is distributed under the MIT license.
+## Contents copyright (c) 2016 by Rex Kerr, Calico Life Sciences, and Open Worm.
+
+#############################################
+# Example of a minimal WCON reader in Julia #
+#############################################
+
 module TrackerCommonsMinimal
 
 import JSON

--- a/src/julia/src/ReadBasic.jl
+++ b/src/julia/src/ReadBasic.jl
@@ -46,3 +46,13 @@ function make_dbl_array_array(q::Any, n::Int64)
         result
     end
 end
+
+function extract_custom(d :: Dict{AbstractString, Any})
+    dd = Dict{AbstractString, Any}()
+    for (k,v) in d
+        if startswith(k, "@")
+            dd[k] = v
+        end
+    end
+    dd
+end

--- a/src/julia/src/ReadBasic.jl
+++ b/src/julia/src/ReadBasic.jl
@@ -1,3 +1,7 @@
+## This file is part of Open Worm's Tracker Commons project and is distributed under the MIT license.
+## Contents copyright (c) 2016 by Rex Kerr, Calico Life Sciences, and Open Worm.
+
+
 ###########################################
 ### Get numeric data out of parsed JSON ###
 ###########################################

--- a/src/julia/src/ReadWcon.jl
+++ b/src/julia/src/ReadWcon.jl
@@ -1,0 +1,52 @@
+module TrackerCommons
+
+###########################################
+### Get numeric data out of parsed JSON ###
+###########################################
+
+function make_dbl(a)
+    x::Float64 = isa(a, Number) ? convert(Float64, a) : NaN
+    x
+end
+
+function make_dbl_array(q::Any)
+    if (typeof(q) <: Array)
+        # Do it this way because map of Any array might still be Any
+        result = zeros(length(q))
+        for i in 1:length(q)
+            result[i] = make_dbl(q[i])
+        end
+        result
+    else [make_dbl(q)]
+    end
+end
+
+function make_dbl_array(q::Any, n::Int64)
+    if (typeof(q) <: Array)
+        # Do it this way because map of Any array might still be Any
+        result = Array(Float64, n)
+        for i in 1:length(q)
+            result[i] = make_dbl(q[i])
+        end
+        result
+    else fill(make_dbl(q), n)
+    end
+end
+
+function make_dbl_array_array(q::Any, n::Int64)
+    if (n == 1)
+        if (length(q)==1 && typeof(q[1]) <: Array)
+            Array[make_dbl_array(q[1])]
+        else
+            Array[make_dbl_array(q)]
+        end
+    else
+        result = Array(Array{Float64, 1}, n)
+        for i in 1:length(q)
+            result[i] = make_dbl_array(q[i])
+        end
+        result
+    end
+end
+
+[]

--- a/src/julia/src/ReadWcon.jl
+++ b/src/julia/src/ReadWcon.jl
@@ -1,5 +1,3 @@
-module TrackerCommons
-
 ###########################################
 ### Get numeric data out of parsed JSON ###
 ###########################################
@@ -48,5 +46,3 @@ function make_dbl_array_array(q::Any, n::Int64)
         result
     end
 end
-
-[]

--- a/src/julia/src/ReadWrite.jl
+++ b/src/julia/src/ReadWrite.jl
@@ -1,0 +1,12 @@
+
+function read_file()
+end
+
+function read_all_files()
+end
+
+function write_file()
+end
+
+function write_all_files()
+end

--- a/src/julia/src/ReadWrite.jl
+++ b/src/julia/src/ReadWrite.jl
@@ -1,12 +1,49 @@
+import JSON
 
-function read_file()
+function read_file(fullname :: AbstractString)
+    result :: Union{AbstractString, DataSet} = ""
+    j = JSON.parsefile(fullname)
+    result = parsed_json_to_dataset(j, fullname)
+    return result
 end
 
-function read_all_files()
+function read_all_files(fullname :: AbstractString)
+    result :: Union{AbstractString, Array{DataSet, 1}} = ""
+    fwd = Array{DataSet, 1}()
+    bkw = Array{DataSet, 1}()
+    first = read_file(fullname)
+    if isa(first, AbstractString)
+        result = convert(AbstractString, first)
+        return result
+    end
+    working :: DataSet = first
+    while !working.prev_filename.isnull
+        more = read_file(working.prev_filename.value)
+        if isa(more, AbstractString)
+            result = string("Read ", 1 + length(bkw), " files successfully but failed on ", working.prev_filename.value, ".  ", convert(AbstractString, more))
+            return result
+        end
+        push!(bkw, more)
+        working = more
+    end
+    working = first
+    while !working.next_filename.isnull
+        more = read_file(working.next_filename.value)
+        if isa(more, AbstractString)
+            result = string("Read ", 1 + length(bkw) + length(fwd), " files successfully but failed on ", working.next_filename.value, ".  ", convert(AbstractString, more))
+            return result
+        end
+        push!(fwd, more)
+        working = more
+    end
+    result = [reverse(bkw); [first]; fwd]
+    return result
 end
 
-function write_file()
-end
-
-function write_all_files()
+function write_file(ds :: DataSet, fullname :: Nullable{AbstractString})
+    j = convert_for_json(ds)
+    fn = (fullname.isnull) ? ds.this_name : fullname.value
+    fh = open(fn, "w")
+    JSON.print(fh, j)
+    close(fh)
 end

--- a/src/julia/src/ReadWrite.jl
+++ b/src/julia/src/ReadWrite.jl
@@ -1,3 +1,11 @@
+## This file is part of Open Worm's Tracker Commons project and is distributed under the MIT license.
+## Contents copyright (c) 2016 by Rex Kerr, Calico Life Sciences, and Open Worm.
+
+##################################
+# WCON file I/O via JSON parser #
+#################################
+
+
 import JSON
 
 function read_file(fullname :: AbstractString)

--- a/src/julia/src/Units.jl
+++ b/src/julia/src/Units.jl
@@ -145,6 +145,13 @@ type KnownUnits
     custom :: Dict{AbstractString, Any}
 end
 
+function minimal_known_units()
+    convert(
+      KnownUnits,
+      parsed_json_to_units(Dict{AbstractString, Any}("t" => "s", "x" => "mm", "y" => "mm"))
+    )
+end
+
 function convert_for_json(ku :: KnownUnits)
     result = Dict{AbstractString, Any}()
     for (k,v) in ku.mapper

--- a/src/julia/src/Units.jl
+++ b/src/julia/src/Units.jl
@@ -1,0 +1,135 @@
+
+si_prefix_map = Dict(
+    "c" => 1e-2,
+    "centi" => 1e-2,
+    "m" => 1e-3,
+    "milli" => 1e-3,
+    "u" => 1e-6,
+    "\u00B5" => 1e-6,
+    "\u03BC" => 1e-6,
+    "micro" => 1e-6,
+    "n" => 1e-9,
+    "nano" => 1e-9,
+    "k" => 1e3,
+    "kilo" => 1e3,
+    "M" => 1e6,
+    "mega" => 1e6,
+    "G" => 1e9,
+    "giga" => 1e9
+)
+
+nonscaled_units_to_internal = Dict(
+    "C" => x :: Float64 -> x,
+    "K" => x :: Float64 -> x - 273.15,
+    "F" => x :: Float64 -> ((x - 32)*5.0)/9.0
+)
+
+nonscaled_units_to_external = Dict(
+    "C" => x :: Float64 -> x,
+    "K" => x :: Float64 -> x + 273.15,
+    "F" => x :: Float64 -> (x*9.0)/5.0 + 32
+)
+
+long_units_list = collect(Dict(
+    "meter" => 1e3,
+    "metre" => 1e3,
+    "meters" => 1e3,
+    "metres" => 1e3,
+    "micron" => 1e-3,
+    "microns" => 1e-3,
+    "inch" => 25.4,
+    "inches"=> 25.4,
+    "second" => 1.0,
+    "seconds" => 1.0,
+    "minute" => 60.0,
+    "minutes" => 60.0,
+    "hour" => 3600.0,
+    "hours" => 3600.0,
+    "day" => 86400.0,
+    "days" => 86400.0
+))
+
+abbrev_units_list = collect(Dict(
+    "1" => 1.0,
+    "%" => 0.01,
+    "m" => 1e3,
+    "in" => 25.4,
+    "s" => 1.0,
+    "min" => 60.0,
+    "h" => 3600.0,
+    "hr" => 3600.0,
+    "d" => 86400.0
+))
+
+function make_nonscaled_converters(input :: AbstractString)
+    result :: Nullable{Tuple{Function, Function}} = Nullable{Tuple{Function, Function}}()
+    if haskey(nonscaled_units_to_internal, input) && haskey(nonscaled_units_to_external)
+        result = Nullable(nonscaled_units_to_internal(input), nonscaled_units_to_external(input))
+    end
+    return result
+end
+
+function make_simple_scale(input :: AbstractString)
+    result :: Float64 = NaN
+    tidy = strip(input)
+    longi = findfirst(x -> endswith(tidy, first(x)), long_units_list)
+    if longi > 0
+        k, v = long_units_list[longi]
+        if tidy == k result = v
+        else
+            pre = tidy[1:(length(tidy) - length(k))]
+            if haskey(si_prefix_map, pre) && length(pre) > 1
+                result = v * si_prefix_map(pre)
+            end
+        end
+    else
+        shorti = findfirst(x -> endswith(input,first(x)), abbrev_units_list)
+        if shorti > 0
+            k, v = abbrev_units_list[shorti]
+            if tidy == k result = v
+            elseif k != "1" && k != "%"
+                pre = tidy[1:(length(tidy)-length(k))]
+                if haskey(si_prefix_map, pre) && length(pre) == 1
+                    result = v * si_prefix_map(pre)
+                end
+            end
+        end
+    end
+end
+
+function make_complex_scale(input :: AbstractString)
+    result :: Float64 = NaN
+    div = findfirst(input, '/')
+    if (div > 0)
+        result = make_complex_scale(input[1:(div-1)]) / make_complex_scale(input[(div+1):end])
+    else
+        mul = findfirst(input, '*')
+        if (mul > 0)
+            result = make_complex_scale(input[1:(mul-1)]) * make_complex_scale(input[(div+1):end])
+        else
+            pwr = findfirst(input, '^')
+            if (pwr > 0)
+                result = make_simple_scale(input[1:(pwr-1)]) ^ (try parse(Int8, strip(input[(pwr+1):end])) catch; NaN end)
+            else
+                result = make_simple_scale(input)
+            end
+        end
+    end
+    return result
+end
+
+function make_complex_converters(input :: AbstractString)
+    result :: Nullable{Tuple{Function, Function}} = Nullable{Tuple{Function, Function}}()
+    sks = make_complex_scale(input)
+    if !isnan(sks)
+        result = Nullable((x :: Float64 -> x * sks, x :: Float64 -> x / sks))
+    end
+    return result
+end
+
+function make_any_converters(input :: AbstractString)
+    result :: Nullable{Tuple{Function, Function}} = Nullable{Tuple{Function, Function}}()
+    nsc = make_nonscaled_converters(strip(input))
+    result = nsc.isnull ? make_complex_converters(input) : Nullable(nsc.value)
+    return result
+end

--- a/src/julia/src/Units.jl
+++ b/src/julia/src/Units.jl
@@ -1,3 +1,10 @@
+## This file is part of Open Worm's Tracker Commons project and is distributed under the MIT license.
+## Contents copyright (c) 2016 by Rex Kerr, Calico Life Sciences, and Open Worm.
+
+#################################################
+# Implementation of Tracker Commons recommended #
+# unit conversions for WCON format              #
+#################################################
 
 si_prefix_map = Dict(
     "c" => 1e-2,

--- a/src/julia/src/Units.jl
+++ b/src/julia/src/Units.jl
@@ -214,11 +214,11 @@ function parsed_json_to_units(x :: Dict{AbstractString, Any})
     return result
 end
 
-function floatize_any_array(a :: Array)
+function floatize_any_array(a :: Array{})
     if isa(a, Array{Float64, 1})
         return a
     end
-    result = fill(NaN)(length(a))
+    result = fill(NaN, length(a))
     for i in 1:length(a)
         x = a[i]
         if isa(x, Number)
@@ -242,10 +242,10 @@ function internalize_parsed_json!(j :: Any, ku :: KnownUnits, uc :: Nullable{Uni
                     d[k] = uk.value.to_internal(convert(Float64, v))
                 else
                     x =
-                        if isa(j, Array)
-                            if isa(j, Array{Float64, 1}) convert(Array{Float64, 1}, j)
+                        if isa(v, Array{})
+                            if isa(v, Array{Float64, 1}) convert(Array{Float64, 1}, j)
                             else
-                                y = floatize_any_array(convert(Array, j))
+                                y = floatize_any_array(convert(Array{}, v))
                                 d[k] = y
                                 y
                             end
@@ -256,14 +256,14 @@ function internalize_parsed_json!(j :: Any, ku :: KnownUnits, uc :: Nullable{Uni
                 end
             end
         end
-    elseif isa(j, Array)
-        ja = convert(j, Array)
+    elseif isa(j, Array{})
+        ja = convert(Array{}, j)
         for i in 1:length(ja)
             ji = ja[i]
             if isa(ji, Number) && !uc.isnull
                 ja[i] = uc.value.to_internal(convert(Float64, ji))
             else
-                if isa(ji, Array)
+                if isa(ji, Array{})
                     x = floatize_any_array(ji)
                     if isa(x, Array{Float64, 1})
                         ja[i] = x
@@ -298,7 +298,7 @@ function externalize_jsonable!(j :: Any, ku :: KnownUnits, uc :: Nullable{UnitCo
                 end
             end
         end
-    elseif isa(j, Array)
+    elseif isa(j, Array{})
         if isa(j, Array{Float64, 1}) && !uc.isnull
             fn = uc.value.to_external
             jf = convert(Array{Float64, 1}, j)
@@ -306,14 +306,14 @@ function externalize_jsonable!(j :: Any, ku :: KnownUnits, uc :: Nullable{UnitCo
                 jf[i] = fn(jf[i])
             end
         else
-            ja = convert(Array, j)
+            ja = convert(Array{}, j)
             if uc.isnull
                 for v in ja externalize_jsonable!(v, ku, uc) end
             else
                 for i in 1:length(ja)
                     if isa(ja[i], Float64) ja[i] = fn(convert(Float64,ja[i]))
                     else
-                        externalized_jsonable!(v, ku, uc)
+                        externalize_jsonable!(ja[i], ku, uc)
                     end
                 end
             end


### PR DESCRIPTION
This patch fully implements (save bugs, of which there are probably many) a Julia implementation of the Tracker Commons WCON format.  Both reading and writing are supported, though multiple file writing is not supported (the `files` tag is not emitted).

Again, fair warning: since Julia is not a compiled language, there are probably all sorts of bugs lurking in this implementation that will be found with an extensive test suite and/or innocent usage on real data.  However, this implementation is at least highly complete documentation of what is necessary to produce a robust Julia implementation.
