### PR TITLE
Updated README to reflect Semaphore CI running Scala.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ five points along the worm's spine.
 
 The Tracker Commons repository contains implementations for reading and writing WCON data for a variety of languages.  Browse the `src` directory to learn more!
 
-| Language  | Principal Author  |  Status |
-| ------------- | ------------- | ------------- |
-| [Scala](src/scala)  | Rex Kerr  | Available |
-| [Julia](src/julia)  | Rex Kerr  | Available |
-| [Python](src/Python)  | Michael Currie | Available [![Build Status](https://travis-ci.org/openworm/tracker-commons.svg?branch=master)](https://travis-ci.org/openworm/tracker-commons) [![PyPI package](https://badge.fury.io/py/wcon.svg)](http://badge.fury.io/py/wcon)  |
-| [R](src/R)  | n/a  | Preliminary notes only |
-| [Rust](src/Rust)  | n/a  | Preliminary notes only |
-| Matlab  | n/a  | [Currently seeking contributors](https://github.com/openworm/tracker-commons/issues/45) |
-| Octave  | n/a  | [Currently seeking contributors](https://github.com/openworm/tracker-commons/issues/45) |
+| Language  | Principal Author  |  Capabilities |  Test Status | Packaged? |
+| ------------- | ------------- | ------------- | ----------------- |------|
+| [Scala](src/scala)  | Rex Kerr  | Feature-complete, beta  | [![Build Status](https://semaphoreci.com/api/v1/ichoran/tracker-commons/branches/master/badge.svg)](https://semaphoreci.com/ichoran/tracker-commons) | no |
+| [Julia](src/julia)  | Rex Kerr  | Runnable implementation (alpha) | none | no |
+| [Python](src/Python)  | Michael Currie | Feature-complete, beta | [![Build Status](https://travis-ci.org/openworm/tracker-commons.svg?branch=master)](https://travis-ci.org/openworm/tracker-commons) | [![PyPI package](https://badge.fury.io/py/wcon.svg)](http://badge.fury.io/py/wcon)  |
+| [R](src/R)  | n/a  | Preliminary notes only | n/a | no |
+| [Rust](src/Rust)  | n/a  | Preliminary notes only | n/a | no |
+| Matlab  | n/a  | [Currently seeking contributors](https://github.com/openworm/tracker-commons/issues/45) | n/a | no |
+| Octave  | n/a  | [Currently seeking contributors](https://github.com/openworm/tracker-commons/issues/45) | n/a | no |


### PR DESCRIPTION
Set up Semaphore CI under my GitHub account, also.
