### PR TITLE
Scalars in unit expressions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,13 @@ before_install:
     - which python
     - python --version
     - pydoc modules
+
+before_script:
+    - ls -l
+    - cd $TRAVIS_BUILD_DIR
+    - ls -l
+    - wget "https://drive.google.com/uc?export=download&id=0B9dU7zPD0s_LRkNzS0N3VnhoODQ" -O from_schafer_lab.wcon
+    - pwd
  
 script:
     # Run pep8 on all .py files in all subfolders

--- a/WCON_format.md
+++ b/WCON_format.md
@@ -82,7 +82,9 @@ We recommend that this be done not just for values specified in the base WCON fo
 The WCON readers and writers provided in the Tracker Commons package internally represent times in seconds and distances
 in millimeters; when it is practical, we encourage other labs to adopt these to reduce the risk of loss of precision or inaccurate values due to unit conversions.  Seconds can be specified as one of `"s"`, `"second"`, or `"seconds"`), and millimetres are specified as one of `"mm"`, `"millimetre"`, or `"millimetres"`, or the American English versions "millimeter" or "millimeters".
 
-For compound units, `*` can be used for multiplication, `/` for division, and `^` for exponentiation.  For instance, a unit of acceleration could be written `"mm^2/s"`.  Use `"1"` for a unitless quantity (or `"%"`, as appropriate).
+For compound units, `*` can be used for multiplication, `/` for division, and `^` for exponentiation.  For instance, a unit of acceleration could be written `"mm^2/s"`.  Use `"1"` for a unitless quantity (or `"%"`, as appropriate).  `""` is treated as `"1"`.
+
+Other numerical values may be used in the expressions: for instance, `"0.04*s"` can be used for frame indices in a 25 FPS sample.
 
 `"units"` is required and must be single-valued.  Units must be specified at least for `"t"`, `"x"`, and `"y"`.
 

--- a/src/Python/tests/tests.py
+++ b/src/Python/tests/tests.py
@@ -75,6 +75,15 @@ class TestDocumentationExamples(unittest.TestCase):
 
 class TestMeasurementUnit(unittest.TestCase):
 
+    def test_units_with_numbers(self):
+        MU = MeasurementUnit
+        self.assertTrue(MU.create('0.04*s').to_canon(1) == 0.04)
+        self.assertTrue(MU.create('0.04/C').to_canon(1) == 0.04)
+        self.assertTrue(MU.create('0.04/us').to_canon(-34.5) == -1380000)
+        self.assertTrue(MU.create('4').from_canon(4) == 1)
+        self.assertTrue(MU.create('0.04*s').canonical_unit_string == 's')
+        self.assertTrue(MU.create('1/234234').canonical_unit_string == '')
+
     def test_unit_equivalence(self):
         MU = MeasurementUnit
         self.assertTrue(MU.create('mm') == MU.create('millimetre'))

--- a/src/Python/wcon/wcon_parser.py
+++ b/src/Python/wcon/wcon_parser.py
@@ -17,6 +17,7 @@ from six import StringIO
 from os import path
 import json
 import jsonschema
+import numpy as np
 import pandas as pd
 idx = pd.IndexSlice
 
@@ -334,6 +335,15 @@ class WCONWorms():
                 # Just ignore cases where there are "units" entries but no
                 # corresponding data
                 pass
+
+        # Special case: change the dataframe index, i.e. the time units
+        tmu = self.units['t']
+        if tmu.unit_string != tmu.canonical_unit_string:
+            # Create a function that can be applied elementwise to the
+            # index values
+            t_converter = np.vectorize(tmu.to_canon)
+
+            w.data.set_index(t_converter(w.data.index.values), inplace=True)
 
         # Go through each "units" attribute
         return w


### PR DESCRIPTION
e.g. '5*s', '3/m^2', etc.

2608333e0ae5df54032fe0bd60c11464a24dd29c now allows us to specify '0.04*s' as the units for a 25fps skeleton file indexed by frame number, and it will properly convert to seconds.

d80ddfe makes the format specification consistent with allowing scaling factors on units.  As @Ichoran points out, this pull request is still pending @aexbrown's approval on that idea though.
