### PR TITLE
Python speedfix2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,13 @@ python:
     # test_save_and_load fails on minimax.wcon with Python 3.3, and I haven't had 
     # create a Python 3.3 debugging environment to find out why
     #- 3.3  
-    - 3.4
+    - 3.4.4
     - 3.5
 
 notifications:
   email: false
 
 before_install:
-    - sudo apt-get update
-    - sudo apt-get -y install python-pip
     - pip install --upgrade pip
     - pip install six
     - pip install pep8

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ before_script:
     - wget "https://www.dropbox.com/s/apjyc9lh1t7646q/XJ30_NaCl500mM4uL6h_10m45x10s40s_Ea.wcon?dl=1" -O from_kerr.wcon
     # Zip the downloaded files so zipped versions can also be tested
     - zip from_schafer_lab_zipped.wcon from_schafer_lab.wcon
-    - zip from_kerr_zipped.wcon from_kerr_lab.wcon
+    - zip from_kerr_zipped.wcon from_kerr.wcon
     - ls -l
     - cd $TRAVIS_BUILD_DIR
  

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
     # test_save_and_load fails on minimax.wcon with Python 3.3, and I haven't had 
     # create a Python 3.3 debugging environment to find out why
     #- 3.3  
-    - 3.4.4
+    - 3.4
     - 3.5
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ python:
     # conda doesn't seem to work with 2.6 so let's forget about testing it
     #- 2.6  
     - 2.7
-    # test_save_and_load fails on minimax.wcon with Python 3.3, and I haven't had 
-    # create a Python 3.3 debugging environment to find out why
+    # test_save_and_load fails on minimax.wcon with Python 3.3, haven't had change to look into it
     #- 3.3  
     - 3.4
     - 3.5
@@ -14,7 +13,6 @@ notifications:
   email: false
 
 before_install:
-    - sudo apt-get update
     - pip install --upgrade pip
     - pip install six
     - pip install pep8

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ notifications:
   email: false
 
 before_install:
+    - sudo apt-get update
     - pip install --upgrade pip
     - pip install six
     - pip install pep8

--- a/src/Python/README.md
+++ b/src/Python/README.md
@@ -52,28 +52,58 @@ assert(filecmp.cmp('file1.wcon', file2.wcon'))
 w3 = w1 + w2  # Merge the two.  An exception is raised if the data clashes
 ```
 
+### Formal API
 
-### `WCONWorms` class: Attributes
-
-- `units`: dict
-    - May be empty, but is never None since 'units' is required 
-    to be specified.
-- `metadata`: dict
-    - If 'metadata' was not specified, metadata is None.
-    - The values in this dict might be nested into further dicts or other
-    data types.
-- `data`: Pandas DataFrame or None
-    - If 'data' was not specified, data is None.
-- [Note: `files`, if present in the input, is not persisted unless the `.load`
-       factory method is used.]
-
-### `WCONWorms` class: Public-Facing Methods
-
-- `load_from_file`   (JSON_path)                [class method]
-- `save_to_file`     (JSON_path, pretty_print)
-- `to_canon`                                    [property]
-- `__add__`                                     [use `+`]
-- `__eq__`                                      [use `==`]
+- Class `WCONWorms`
+  - methods
+    - `load_from_file`
+      - [class method]
+      - parameters:
+        - `JSON_path`, a `str`, the path of the file
+    - `save_to_file`
+      - parameters:
+        - `JSON_path`, a `str`, the path of the file
+        - `compress_file`, a boolean, whether to compress the file
+        - `pretty_print`, a boolean, whether to render the output on multiple lines
+    - `to_canon`
+      - [property]
+      - returns: a copy of this object but in canonical form
+    - `__add__`
+      - [use `+`]
+    - `__eq__`
+      - [use `==`]
+  - attributes
+    - `units`: dict
+        - May be empty, but is never None since 'units' is required 
+        to be specified.
+    - `metadata`: dict
+        - If 'metadata' was not specified, metadata is None.
+        - The values in this dict might be nested into further dicts or other
+        data types.
+    - `data`: Pandas DataFrame or None
+        - If 'data' was not specified, data is None.
+    - [Note: `files`, if present in the input, is not persisted unless the `.load`
+           factory method is used.]
+- Class `MeasurementUnit`
+  - Note: this class does not need to be used publicly, but it can be if desired.
+    - consequently it can be ommitted from a public API
+  - methods
+    - `create`
+      - [class method]
+      - Factory method
+      - parameter: `unit_string`, a `str`, the unit expression (e.g. `"mm"` or `"cm/s"` or `"C"`)
+      - returns: an instance of this class
+    - `to_canon`
+      - transforms `v` from original units to canonical units
+      - parameter: `v` (a `float`)
+      - returns: float
+    - `from_canon`
+      - the inverse of `to_canon`
+  - attributes
+    - `unit_string`: str
+      - The original string (e.g. `"m/s^2"`)
+    - `canonical_unit_string`: str
+      - The canonical form for all units within the original string (e.g. `"mm/s^2"`)
 
 ### Custom WCON objects
 

--- a/src/Python/tests/diagnostic_test.py
+++ b/src/Python/tests/diagnostic_test.py
@@ -23,30 +23,45 @@ sys.path.append('..')
 from wcon import WCONWorms, MeasurementUnit
 from wcon.measurement_unit import MeasurementUnitAtom
 
+
+def timing_function():
+    """
+    There's a better timing function available in Python 3.3+
+    Otherwise use the old one.
+
+    """
+    if sys.version_info[0] >= 3 and sys.version_info[1] >= 3:
+        return time.monotonic()
+    else:
+        return time.time()
+
 if __name__ == '__main__':
+    # def test_big_file():
     print("BIG TEST: Test load and save and load and save")
     files_to_test = [sys.argv[1]]
 
     for JSON_path in files_to_test:
-        for pretty in [True, False]:
+        for pretty in [True]:  # , False]:
             print("LOADING FOR TEST: " + JSON_path +
                   " (PRETTY = " + str(pretty) + ")")
 
-            start_time = time.monotonic()
+            start_time = timing_function()
             w1 = WCONWorms.load_from_file(JSON_path,
                                           validate_against_schema=False)
-            print("Time to load w1: " + str(time.monotonic() - start_time))
+            print("Time to load w1: " + str(timing_function() - start_time))
+
+            continue
 
             # Save these worm tracks to a file, then load that file
             test_path = 'test.wcon'
-            start_time = time.monotonic()
+            start_time = timing_function()
             w1.save_to_file(test_path, pretty_print=pretty)
-            print("Time to save w1: " + str(time.monotonic() - start_time))
+            print("Time to save w1: " + str(timing_function() - start_time))
 
-            start_time = time.monotonic()
+            start_time = timing_function()
             w2 = WCONWorms.load_from_file(test_path,
                                           validate_against_schema=False)
-            print("Time to load w2: " + str(time.monotonic() - start_time))
+            print("Time to load w2: " + str(timing_function() - start_time))
 
             x1 = w1.data.loc[:, idx[0, 'x', 0]].fillna(0)
             x2 = w2.data.loc[:, idx[0, 'x', 0]].fillna(0)

--- a/src/Python/tests/diagnostic_test.py
+++ b/src/Python/tests/diagnostic_test.py
@@ -50,8 +50,6 @@ if __name__ == '__main__':
                                           validate_against_schema=False)
             print("Time to load w1: " + str(timing_function() - start_time))
 
-            continue
-
             # Save these worm tracks to a file, then load that file
             test_path = 'test.wcon'
             start_time = timing_function()
@@ -63,11 +61,11 @@ if __name__ == '__main__':
                                           validate_against_schema=False)
             print("Time to load w2: " + str(timing_function() - start_time))
 
-            x1 = w1.data.loc[:, idx[0, 'x', 0]].fillna(0)
-            x2 = w2.data.loc[:, idx[0, 'x', 0]].fillna(0)
-            cmm = np.flatnonzero(x1 != x2)
-            xx = pd.concat([x1, x2], axis=1)
-            xx = xx.loc[cmm]
+            # x1 = w1.data.loc[:, idx[0, 'x', 0]].fillna(0)
+            # x2 = w2.data.loc[:, idx[0, 'x', 0]].fillna(0)
+            # cmm = np.flatnonzero(x1 != x2)
+            # xx = pd.concat([x1, x2], axis=1)
+            # xx = xx.loc[cmm]
 
             # Then load and save AGAIN and do a file comparison to make
             # sure it's the same

--- a/src/Python/tests/tests.py
+++ b/src/Python/tests/tests.py
@@ -172,8 +172,6 @@ class TestWCONParser(unittest.TestCase):
         w2c = w2.to_canon
         # A change to_canon should change the data in one but equality
         # should remain
-        self.assertFalse((w2.data == w2c.data).all().all())
-        # This has the same effect as above
         self.assertFalse(WCONWorms.is_data_equal(w2, w2c, convert_units=False))
         self.assertEqual(w2, w2)
         self.assertEqual(w2c, w2c)
@@ -183,10 +181,6 @@ class TestWCONParser(unittest.TestCase):
         # force a difference now, with w2c)
         w2.units['y'] = MeasurementUnit.create('mm')
         self.assertNotEqual(w2, w2c)
-
-        # Confirm that data was not altered in situ after performing
-        # the to_canon operation
-        self.assertTrue((w2data == w2.data).any().any())
 
     def test_save_and_load(self):
         """
@@ -487,13 +481,13 @@ class TestWCONParser(unittest.TestCase):
 
         # Modifying w2's data in just one spot is enough to make the data
         # clash and the merge should fail
-        w2.data.loc[1.3, (1, 'x', 0)] = 4000
+        w2._data[1].loc[1.3, (1, 'x', 0)] = 4000
         with self.assertRaises(AssertionError):
             w4 = w2 + w3
 
-        # But if we drop that entire row in w2, it should accomodate the new
+        # But if we drop that entire row in w3, it should accomodate the new
         # figure
-        w3.data.drop(1.3, axis=0, inplace=True)
+        w3._data[1].drop(1.3, axis=0, inplace=True)
         w4 = w2 + w3
         self.assertEqual(w4.data.loc[1.3, (1, 'x', 0)], 4000)
 

--- a/src/Python/tests/tests.py
+++ b/src/Python/tests/tests.py
@@ -204,12 +204,14 @@ class TestWCONParser(unittest.TestCase):
                 print("LOADING FOR TEST: " + JSON_path +
                       " (PRETTY = " + str(pretty) + ")")
 
-                w_loaded = WCONWorms.load_from_file(JSON_path)
+                w_loaded = WCONWorms.load_from_file(
+                    JSON_path, validate_against_schema=False)
 
                 # Save these worm tracks to a file, then load that file
                 test_path = 'test.wcon'
                 w_loaded.save_to_file(test_path, pretty_print=pretty)
-                w_from_saved = WCONWorms.load_from_file(test_path)
+                w_from_saved = WCONWorms.load_from_file(
+                    test_path, validate_against_schema=False)
 
                 self.assertEqual(w_loaded, w_from_saved)
 
@@ -219,7 +221,8 @@ class TestWCONParser(unittest.TestCase):
                 # isn't in the WCON standard it's nice for human
                 # readability, i.e. to have "units" before "data",
                 # "id" first in a data segment, etc.)
-                w_loaded_again = WCONWorms.load_from_file(test_path)
+                w_loaded_again = WCONWorms.load_from_file(
+                    test_path, validate_against_schema=False)
                 self.assertEqual(w_loaded, w_loaded_again)
                 self.assertEqual(w_loaded, w_from_saved)
                 self.assertEqual(w_loaded_again, w_from_saved)

--- a/src/Python/wcon/wcon_data.py
+++ b/src/Python/wcon/wcon_data.py
@@ -316,6 +316,7 @@ def parse_data(data):
 
     return time_df
 
+
 def _obtain_time_series_data_frame(time_series_data):
     """
     Obtain a time-series pandas DataFrame
@@ -421,8 +422,15 @@ def _obtain_time_series_data_frame(time_series_data):
 
     # if worm_ids are mutually distinct in each dataframe, then
     if len(set(worm_ids_flat)) == len(worm_ids):
-        time_df = reduce(lambda l,r: pd.merge(l, r, left_index=True,
-                         right_index=True, how='outer'), data_segment_dfs)
+        time_df = reduce(
+            lambda l,
+            r: pd.merge(
+                l,
+                r,
+                left_index=True,
+                right_index=True,
+                how='outer'),
+            data_segment_dfs)
     else:
         # Otherwise we have to iterate
         # TODO: we could do the above time shortcut with all available

--- a/src/Python/wcon/wcon_data.py
+++ b/src/Python/wcon/wcon_data.py
@@ -87,13 +87,6 @@ def df_upsert(src, dest):
     # to use the operation over several datasets, use a list comprehension."
 
     """
-    # Sort the columns
-    # DEBUG: disabled because it doesn't appear necessary to do this, and this
-    #        saves oodles of time
-    # dest.sort_index(axis=1, inplace=True)
-    #import pdb
-    #pdb.set_trace()
-
     # Add all columns for worms that don't currently exist in dest
     # but have entries on the same timeframes
     if not any(src.columns.isin(dest.columns)):

--- a/src/Python/wcon/wcon_data.py
+++ b/src/Python/wcon/wcon_data.py
@@ -28,7 +28,7 @@ elements_without_aspect = ['ox', 'oy', 'cx', 'cy', 'head', 'ventral']
 basic_data_keys = elements_with_aspect + elements_without_aspect
 supported_data_keys = basic_data_keys + ['id', 't']
 MIN_FRAMES_FOR_MULTIPROCESSING = 3000  # This is somewhat arbitrary
-USE_MULTIPROCESSING = True
+USE_MULTIPROCESSING = False
 
 
 def get_mask(arr, desired_key):

--- a/src/Python/wcon/wcon_data.py
+++ b/src/Python/wcon/wcon_data.py
@@ -404,7 +404,7 @@ def _obtain_time_series_data_frame(time_series_data):
 
         # If we don't do this, for very large files (>50 MB) the memory
         # footprint grows until the program crashes
-        # gc.collect()
+        gc.collect()
 
         # Add the segment to our main DataFrame
         if time_df is None:

--- a/src/Python/wcon/wcon_data.py
+++ b/src/Python/wcon/wcon_data.py
@@ -95,7 +95,7 @@ def df_upsert(src, dest):
                         right_index=True, how='outer')
     else:
         # Scenario 2: src is worm already in dest.
-        
+
         # Handle the timepoints NOT shared with dest
         if any(~src.index.isin(dest.index)):
             # Add all rows that don't currently exist in dest

--- a/src/Python/wcon/wcon_parser.py
+++ b/src/Python/wcon/wcon_parser.py
@@ -508,7 +508,7 @@ class WCONWorms():
                 # Note: the first file is all we should need since we assume
                 #       the files in the archive are linked together using
                 #       their respective JSON "files" entries
-                
+
                 # Make a temporary archive folder
                 cur_path = os.path.abspath(os.path.dirname(JSON_path))
                 archive_path = os.path.join(cur_path, '_zip_archive')


### PR DESCRIPTION
This commit is the improved PR #68 .

I can't figure out how to get the zip commits to not appear here, so that both the zipfiles and python_speedfix2 branches just show their respective commits relative to master.

Instead, as you can see below, the commits below include those for zipfiles.  Perhaps if zipfiles is merged with master, those commits will disappear here.
