### PR TITLE
Updated Tracker-Commons metadata

### DIFF
--- a/.openworm.yml
+++ b/.openworm.yml
@@ -4,9 +4,26 @@ shortDescription: "Compilation of information and code bases related to open-sou
 coordinator: mcurrie@openworm.org
 documentation: https://github.com/openworm/tracker-commons/blob/master/README.md
 gitter: https://gitter.im/openworm/open-worm-analysis-toolbox
+keywords:
+  - data
+languages:
+  - scala
+  - python
+  - java
+  - r
+  - julia
+  - octave
+  - matlab
+  - c
+  - c++
+latest-release:
+  - beta 1.1.0
+members:
+  - cheelee@openworm.org
 outputs: 
   - openworm/sibernetic
   - openworm/org.geppetto
   - openworm/open-worm-analysis-toolbox
 parent:
   - openworm/open-worm-analysis-toolbox
+tests: true


### PR DESCRIPTION
Metadata now includes information on more fields as listed in: https://github.com/openworm/OpenWorm/issues/220

This change should only affect Giovanni's prototype javascript tool, and should be safe to pull with immediate effect.
