### PR TITLE
Scala perimeters

### DIFF
--- a/src/scala/src/main/scala/Compatibility.scala
+++ b/src/scala/src/main/scala/Compatibility.scala
@@ -382,35 +382,26 @@ class Data(
   def toUnderlying = {
     val nid = Jast.parse(id).double
     val sid = if (nid.isNaN) id else ""
-    val oxs = if (cxs.length == 0) org.openworm.trackercommons.Data.findFloatOffsets(xss) else Data.emptyDoubleArray
-    val oys = if (cys.length == 0) org.openworm.trackercommons.Data.findFloatOffsets(yss) else Data.emptyDoubleArray
+    val rxs = 
+      if (cxs.length == 0) xss.map(_.min.toDouble)
+      else java.util.Arrays.copyOf(cxs, cxs.length)
+    val rys = 
+      if (cys.length == 0) yss.map(_.min.toDouble)
+      else java.util.Arrays.copyOf(cys, cys.length)
     new org.openworm.trackercommons.Data(
       nid, sid,
       java.util.Arrays.copyOf(ts, ts.length),
-      xss.indices.toArray.map(i =>
-        original.Data.singly(
-          xss(i),
-          if (cxs.length > 0) -cxs(i)
-          else if (oxs.length > 1) -oxs(i)
-          else if (oxs.length == 1) -oxs(0)
-          else 0.0
-        )
-      ),
-      yss.indices.toArray.map(i => 
-        original.Data.singly(
-          yss(i),
-          if (cys.length > 0) -cys(i)
-          else if (oys.length > 1) -oys(i)
-          else if (oys.length == 1) -oys(0)
-          else 0.0
-        )
-      ),
+      xss.indices.toArray.map(i => original.Data.singly(xss(i), -rxs(i))),
+      yss.indices.toArray.map(i => original.Data.singly(yss(i), -rys(i))),
       java.util.Arrays.copyOf(cxs, cxs.length),
       java.util.Arrays.copyOf(cys, cys.length),
-      oxs,
-      oys,
+      Data.emptyDoubleArray,
+      Data.emptyDoubleArray,
+      false,
+      None,
+      None,
       custom
-    )
+    )(rxs,rys)
   }
 }
 object Data {
@@ -447,22 +438,15 @@ object Data {
       new MemoizedGenerator(java.util.Arrays.copyOf(underlying.ts, underlying.ts.length)),
       new MemoizedGenerator(java.util.Arrays.copyOf(underlying.cxs, underlying.cxs.length)),
       new MemoizedGenerator(java.util.Arrays.copyOf(underlying.cys, underlying.cys.length)),
-      new MemoizedGenerator(underlying.xs.indices.toArray.map(i =>
+      new MemoizedGenerator(underlying.xDatas.indices.toArray.map(i =>
         org.openworm.trackercommons.Data.doubly(
-          underlying.xs(i),
-          if (underlying.cxs.length > 0 && underlying.cxs(i).finite) underlying.cxs(i)
-          else if (underlying.oxs.length > i) { if (underlying.oxs(i).finite) underlying.oxs(i) else 0.0 }
-          else if (underlying.oxs.length == 1 && underlying.oxs(0).finite) underlying.oxs(0)
-          else 0
+          underlying.xDatas(i), underlying.rxs(i)
         )
       )),
-      new MemoizedGenerator(underlying.ys.indices.toArray.map(i =>
+      new MemoizedGenerator(underlying.yDatas.indices.toArray.map(i =>
         org.openworm.trackercommons.Data.doubly(
-          underlying.ys(i),
-          if (underlying.cys.length > 0 && underlying.cys(i).finite) underlying.cys(i)
-          else if (underlying.oys.length > i) { if (underlying.oys(i).finite) underlying.oys(i) else 0.0 }
-          else if (underlying.oys.length == 1 && underlying.oys(0).finite) underlying.oys(0)
-          else 0
+          underlying.yDatas(i),
+          underlying.rys(i)
         )
       )),
       underlying.custom

--- a/src/scala/src/main/scala/Data.scala
+++ b/src/scala/src/main/scala/Data.scala
@@ -29,93 +29,228 @@ trait HasId extends math.Ordered[HasId] {
 
 case class IdOnly(nid: Double, sid: String) extends HasId {}
 
+/** Trait to specify the perimeter of a single animal. */
+trait Perimeter {
+  def tailIndex: Option[Int]
+  def size: Int
+  def x(i: Int): Double
+  def y(i: Int): Double
+  def getPoints(): (Array[Double], Array[Double])
+}
+
+object NoPerimeter extends Perimeter {
+  private[this] val noPoints = new Array[Double](0)
+  private[this] val noPointsPair = (noPoints, noPoints)
+  def tailIndex = None
+  def size = 0
+  def x(i: Int) = throw new IndexOutOfBoundsException("No perimeter")
+  def y(i: Int) = throw new IndexOutOfBoundsException("No perimeter")
+  def getPoints(): (Array[Double], Array[Double]) = noPointsPair
+}
+
+case class PixelWalk(path: Array[Byte], n: Int, x0: Double, y0: Double, side: Double, tail: Int = -1)(val ocx: Double, val ocy: Double)
+extends Perimeter with AsJson {
+  private[this] var myGxn = 0
+  private[this] var myGyn = 0
+  private[this] var myI = 0
+  def tailIndex = if (tail >= 0) Some(tail) else None
+  def size = n
+  def step(i: Int) = ((path(i >>> 4) & 0xFF) >>> (i & 0x3)) & 0x3
+  private[this] def findI(i: Int) {
+    if (myI < i) {
+      while (myI < i) { 
+        step(myI) match {
+          case 0 => myGxn += 1
+          case 1 => myGyn += 1
+          case 2 => myGxn -= 1
+          case _ => myGyn -= 1
+        }
+        myI -= 1
+      }
+    }
+    else if (myI > i) {
+      while (myI > i) {
+        myI -= 1
+        step(myI) match {
+          case 0 => myGxn -= 1
+          case 1 => myGyn -= 1
+          case 2 => myGxn += 1
+          case _ => myGyn += 1
+        }
+      }
+    }
+  }
+  def x(i: Int) = {
+    if (i != myI) findI(i)
+    x0 + side*myGxn.toDouble
+  }
+  def y(i: Int) = {
+    if (i != myI) findI(i)
+    y0 + side*myGyn.toDouble
+  }
+  def getPoints(): (Array[Double], Array[Double]) = {
+    val xs, ys = new Array[Double](n)
+    var i = 0
+    while (i < n) { xs(i) = x(i); ys(i) = y(i); i += 1 }
+    (xs, ys)
+  }
+  def translate(rx: Double, ry: Double) = new PixelWalk(path, n, x0+rx, y0+ry, side, tail)(rx, ry)
+  def json = {
+    val b = Json ~ ("px", Json.Arr.Dbl(Array(Data.sig(x0-ocx), Data.sig(y0-ocy), side)))
+    if (tail >= 0) b ~ ("n", Json(Array[Double](n, tail)))
+    else b ~ ("n", n)
+    b ~ ("path", path) ~ Json
+  }
+}
+object PixelWalk extends FromJson[PixelWalk] {
+  val empty = new PixelWalk(new Array[Byte](0), 0, 0, 0, 0, -1)(0, 0)
+
+  def parse(j: Json): Either[JastError, PixelWalk] = j match {
+    case o: Json.Obj =>
+      if (o.size != 3) return Left(JastError("PixelWalk must contain exactly three elements"))
+      val ori = o("px") match {
+        case jad: Json.Arr.Dbl if jad.size == 3 => jad.doubles
+        case _ => return Left(JastError("PixelWalk must contain a 'px' field that is an array of three numbers"))
+      }
+      val n = o("n") match {
+        case jn: Json.Num if jn.double.toInt == jn.double =>
+          Array(jn.double.toInt, -1)
+        case jad: Json.Arr.Dbl if jad.size == 2 && jad.doubles(0).toInt == jad.doubles(0) && jad.doubles(1).toInt == jad.doubles(1) =>
+          Array(jad.doubles(0).toInt, jad.doubles(1).toInt)
+        case _ =>
+          return Left(JastError("PixelWalk must contain an 'n' field that is a single integer, or an array of two integers"))
+      }
+      val path = o("path").to[Array[Byte]] match { case Left(je) => return Left(je); case Right(p) => p }
+      if (n(0) > 3*path.length) return Left(JastError("path contains at most ${3*path.length} steps but ${n(0)} declared"))
+      if (n(1) >= n(0)) return Left(JastError("tail index ${n(1)} is outside of path length ${n(0)}"))
+      Right(new PixelWalk(path, n(0), ori(0), ori(1), ori(2).toFloat, n(1))(0, 0))
+    case _ => Left(JastError("JSON value is not an array so cannot be a PixelWalk"))
+  }
+}
+
+case class PerimeterPoints(xData: Array[Float], yData: Array[Float], tailIndex: Option[Int] = None)(val rx: Double, val ry: Double)
+extends Perimeter {
+  val size = math.min(xData.length, yData.length)
+  def x(i: Int) = xData(i) + rx
+  def y(i: Int) = yData(i) + ry
+  def getPoints(): (Array[Double], Array[Double]) = {
+    val px, py = new Array[Double](size)
+    var i = 0
+    while (i < size) {
+      px(i) = xData(i) + rx
+      py(i) = yData(i) + ry
+      i += 1
+    }
+    (px, py)
+  }
+}
+object PerimeterPoints {
+  val empty = new PerimeterPoints(new Array[Float](0), new Array[Float](0), None)(0, 0)
+}
+
 /** Class to specify a single timepoint on a single animal.
-  * Note that `x` and `y` are relative to `cx` and `cy`, if finite;
-  * otherwise they are relative to `ox` and `oy`.
-  * 
-  * To set the policy for encoding the positions, set `originPolicy` to
-  * `Data.OriginPolicy.Never` if the origin should never be output (instead propagated to x, y, cx, cy);
-  * `Data.OriginPolicy.Needed` if the origin should be output only when the centroid is missing;
-  * or `Data.OriginPolicy.Always` if the origin should be output whenever it is present.
+  * Note that `x` and `y` are global, while xData and yData
+  * are relative to `rx` and `ry`.
+  *
+  * The centroid, `cx` and `cy`, is global here.  It appears
+  * relative to `ox` and `oy` in the JSON file.
   */
 case class Datum(
   nid: Double, sid: String,
-  t: Double, x: Array[Float], y: Array[Float],
+  t: Double, xData: Array[Float], yData: Array[Float],
   cx: Double, cy: Double,
   ox: Double, oy: Double,
+  perim: Option[PerimeterPoints],
+  walk: Option[PixelWalk],
   custom: Json.Obj
+)(
+  val rx: Double, val ry: Double
 ) extends HasId with AsJson {
-  var originPolicy: Data.OriginPolicy = Data.OriginPolicy.Needed
-  private[this] val hasO = !(ox.isNaN || oy.isNaN || ox.isInfinite || oy.isInfinite || (ox == 0 && oy == 0))
-  private[this] val hasC = !(cx.isNaN || cy.isNaN || cx.isInfinite || cy.isInfinite)
-  private val gxFix = (if (hasC) cx else if (hasO) ox else 0)
-  private val gyFix = (if (hasC) cx else if (hasO) ox else 0)
+  val hasO = !ox.isNaN && !oy.isNaN && !ox.isInfinite && !oy.isInfinite
+  val hasC = !cx.isNaN && !cy.isNaN && !cx.isInfinite && !cy.isInfinite
+
+  /** The length of the spine */
+  val spineN = math.min(xData.length, yData.length)
 
   /** x coordinate, global coordinates */
-  def gx(i: Int): Double = x(i) + gxFix
+  def x(i: Int): Double = xData(i) + rx
 
   /** y coordinate, global coordinates */
-  def gy(i: Int): Double = y(i) + gyFix
+  def y(i: Int): Double = yData(i) + ry
+
+  /** Global coordinates of spine */
+  def spinePoints(): (Array[Double], Array[Double]) = {
+    val xs, ys = new Array[Double](spineN)
+    var i = 0
+    while (i < spineN) {
+      xs(i) = x(i)
+      ys(i) = y(i)
+      i += 1
+    }
+    (xs, ys)
+  }
+
+  private val myPerim = (perim orElse walk).getOrElse(NoPerimeter)
+
+  val perimN = myPerim.size
+
+  def px(i: Int) = myPerim.x(i)
+
+  def py(i: Int) = myPerim.y(i)
+
+  def perimPoints(): (Array[Double], Array[Double]) = myPerim.getPoints()
+
+  private def externalize(coords: Array[Float], r: Double, o: Double): Array[Double] = {
+    val ext = new Array[Double](coords.length)
+    val delta = r - (if (hasO) o else 0.0)
+    var i = 0
+    while (i < ext.length) {
+      ext(i) = Data.sig(coords(i) + delta)
+      i += 1
+    }
+    ext
+  }
 
   def json = {
     val b = Json ~ ("id", idJSON) ~ ("t", t)
-    val dbx = Data.doubly(x)
-    val dby = Data.doubly(y)
-    originPolicy match {
-      case Data.OriginPolicy.Needed =>
-        if (hasC) b ~ ("cx", cx) ~ ("cy", cy)
-        else if (hasO) b ~ ("ox", ox) ~ ("oy", oy)
-      case Data.OriginPolicy.Never =>
-        if (hasC) b ~ ("cx", cx) ~ ("cy", cy)
-        else if (hasO) {
-          var i = 0; while (i < dbx.length) { dbx(i) += ox; dby(i) += oy; i += 1 }
-        }
-      case Data.OriginPolicy.Always =>
-        if (hasO) {
-          if (hasC) b ~ ("cx", cx - ox) ~ ("cy", cy - oy)
-          b ~ ("ox", ox) ~ ("oy", oy)
-        }
-        else if (hasC) {
-          b ~ ("cx", 0) ~ ("cy", 0) ~ ("ox", ox) ~ ("oy", oy)
-        }
-        else {
-          var lx, ly = 0.0
-          var nx, ny = 0
-          var i = 0
-          while (i < dbx.length) {
-            if (dbx(i).finite) { lx += dbx(i); nx += 1 }
-            if (dby(i).finite) { ly += dby(i); ny += 1 }
-            i += 1
-          }
-          lx = lx / math.max(1, nx)
-          ly = ly / math.max(1, ny)
-          b ~ ("ox", lx) ~ ("oy", ly)
-          i = 0
-          while (i < dbx.length) { dbx(i) -= lx; dby(i) -= ly; i += 1 }
-        }
+    if (hasO) b ~ ("ox", ox) ~ ("oy", oy)
+    if (hasC) {
+      b ~ ("cx", if (hasO) Data.sig(cx - ox) else cx) ~ ("cy", if (hasO) Data.sig(cy - oy) else cy)
     }
-    b ~ ("x", dbx) ~ ("y", dby) ~~ custom ~ Json
+    val dbx = externalize(xData, rx, ox)
+    val dby = externalize(yData, ry, oy)
+    b ~ ("x", Json(dbx)) ~ ("y", Json(dby))
+    if (perim.isDefined) {
+      val ppts = perim.get
+      val px = externalize(ppts.xData, ppts.rx, ox)
+      val py = externalize(ppts.yData, ppts.ry, oy)
+      b ~ ("px", Json(px)) ~ ("py", Json(py)) ~? ("ptail", ppts.tailIndex)
+    }
+    b ~? ("walk", walk) ~~ custom ~ Json
   }
+
   def toData: Data = {
     val d = new Data(
       nid, sid,
-      Array(t), Array(x), Array(y),
+      Array(t), Array(xData), Array(yData),
       if (hasC) Array(cx) else Data.emptyD, if (hasC) Array(cy) else Data.emptyD,
-      if (hasO) Array(ox) else Data.emptyD, if (hasO) Array(oy) else Data.emptyD,
+      if (hasO) Array(ox) else Data.emptyD, if (hasO) Array(oy) else Data.emptyD, false,
+      perim.map(p => Array(p)),
+      walk.map(w => Array(w)),
       custom
-    )
-    d.originPolicy = originPolicy
+    )(Array(rx), Array(ry))
     d
   }
+
   def similarTo(d: Datum, tol: Double, checkCentroids: Boolean): Boolean =
     math.abs(t - d.t) <= tol &&
     (!checkCentroids || (cx.finite == d.cx.finite && cy.finite == d.cy.finite)) &&
     (if (checkCentroids && (cx.finite || cy.finite)) math.abs(cx - d.cx) + math.abs(cy - d.cy) <= 2*tol else true) &&
-    (x.length == d.x.length) &&
+    (spineN == d.spineN) &&
     { var i = 0;
       var close = true;
-      while (i < x.length && close) {
-        close = (x(i) + gxFix - d.x(i) - d.gxFix) <= tol
+      while (i < spineN && close) {
+        close = math.abs(x(i) - d.x(i)) <= tol && math.abs(y(i) - d.y(i)) <= tol
         i += 1
       }
       close
@@ -129,7 +264,47 @@ object Datum extends FromJson[Datum] {
   private def BAD(msg: String): Either[JastError, Nothing] = Left(JastError("Invalid data entry: " + msg))
   private def MYBAD(nid: Double, sid: String, t: Double, msg: String): Either[JastError, Nothing] =
     BAD("Data point for " + IdOnly(nid,sid).idJSON.toString + " at time " + t + " has " + msg)
+  private def sensiblyOffset(hasO: Boolean, o: Double, hasC: Boolean, c: Double, zs: Array[Double], ps: Array[Double]): Double = {
+    var zmin, zmax = zs(0)
+    var i = 0; while (i < zs.length) { if (zs(i) < zmin) zmin = zs(i) else if (zs(i) > zmax) zmax = zs(i); i += 1 }
+    if (math.abs(zmin) < 10 && math.abs(zmax) < 10) {
+      if (hasO) o else 0
+    }
+    else {
+      if (hasC) {
+        val fix = if (hasO) o else 0
+        i = 0; while (i < zs.length) { zs(i) += fix - c; i += 1 }
+        if (ps ne null) { i = 0; while (i < ps.length) { ps(i) += fix - c; i += 1 } }
+        c
+      }
+      else {
+        i = 0; while (i < zs.length) { zs(i) -= zmin; i += 1 }
+        if (ps ne null) { i = 0; while (i < ps.length) { ps(i) -= zmin; i += 1 } }
+        if (hasO) o + zmin else zmin
+      }
+    }
+  }
+  def datumFromValues(
+    nid: Double, sid: String, t: Double,
+    hasO: Boolean, ox: Double, oy: Double,
+    hasC: Boolean, cx0: Double, cy0: Double,
+    x0: Array[Double], y0: Array[Double],
+    px0: Array[Double], py0: Array[Double],
+    walk0: Option[PixelWalk], ptail: Option[Int],
+    o: Json.Obj
+  ): Datum = {
+    val cx = if (hasC && hasO) cx0 + ox else cx0
+    val cy = if (hasC && hasO) cy0 + oy else cy0
+    val rx = sensiblyOffset(hasO, ox, hasC, cx, x0, px0)
+    val ry = sensiblyOffset(hasO, oy, hasC, cy, y0, py0)
+    val walk = walk0.map(_.translate(if (hasO) ox else 0, if (hasO) oy else 0))
+    val peri = 
+      if ((px0 ne null) && (py0 ne null)) Some(PerimeterPoints(Data.singly(px0), Data.singly(py0), ptail)(rx, ry))
+      else None
+    new Datum(nid, sid, t, Data.singly(x0), Data.singly(y0), cx, cy, ox, oy, peri, walk, o)(rx, ry)
+  }
   def parse(j: Json): Either[JastError, Datum] = {
+    implicit val jsonToPixelWalk: FromJson[PixelWalk] = PixelWalk
     val o = j match {
       case jo: Json.Obj => jo
       case _ => return BAD("not a JSON object")
@@ -161,215 +336,217 @@ object Datum extends FromJson[Datum] {
       case _ => return BAD(f"$key is not numeric")
     })
     if ((finC & 1) != 0) return BAD(f"cx $cx0 and cy $cy0 do not agree on whether centroid is finite")
-    val cx = if (finC > 0 && finO > 0) cx0 + ox else cx0
-    val cy = if (finC > 0 && finO > 0) cy0 + oy else cy0
-    val List((x, rx), (y, ry)) = List(("x", cx, ox), ("y", cy, oy)).map{ case (key, c, ori) => 
+    val List((x0, px0), (y0, py0)) = List(("x", "px"), ("y", "py")).map{ case (key, peri) => 
       val values = o(key) match {
-        case Json.Null => if (finC == 0) return MYBAD(nid, sid, t, f"no $key!") else Array(c)
+        case Json.Null => return MYBAD(nid, sid, t, f"no $key!")
         case n: Json.Num => Array(n.double)
         case ns: Json.Arr.Dbl => ns.doubles
-        case _ => return MYBAD(nid, sid, t, f"no valid $key!")
+        case xs: Json.Arr.All if xs.size == 0 => Data.emptyD
+        case je => return MYBAD(nid, sid, t, f"no valid $key was $je (${je.getClass.getName})!")
       }
-      val ri =
-        if (finC > 0 || finO > 0) ori
-        else {
-          var s = 0.0
-          var n, i = 0
-          while (i < values.length) { val vi = values(i); if (!vi.isNaN && !vi.isInfinite) { s += vi; n += 1 }; i += 1 }
-          if (n > 0) {
-            val r = s/n
-            if (!r.isInfinite && math.abs(r) > 1e-9) {
-              i = 0
-              while (i < values.length) { values(i) -= r; i += 1 }
-              r
-            }
-            else 0.0
-          }
-          else 0.0
+      val perivalues = o.get(peri) match {
+        case None => null
+        case Some(j) => j match {
+          case Json.Null => null
+          case n: Json.Num => Array(n.double)
+          case ns: Json.Arr.Dbl => ns.doubles
+          case xs: Json.Arr.All if xs.size == 0 => Data.emptyD
+          case _ => return MYBAD(nid, sid, t, f"$peri is present but not numeric / numeric array")
         }
-      (values, ri)
+      }
+      (values, perivalues)
     }
-    Right((new Datum(nid, sid, t, Data.singly(x), Data.singly(y), cx, cy, rx, ry, o.filter((k,_) => k.startsWith("@")))))
+    if (x0.length != y0.length) return MYBAD(nid, sid, t, "x and y not the same lengths (${x0.length} vs ${y0.length})")
+    if ((px0 eq null) != (py0 eq null)) return MYBAD(nid, sid, t, "Only one of px or py present")
+    if ((px0 ne null) && px0.length != py0.length) return MYBAD(nid, sid, t, "px and py not the same lengths (${px0.length} vs ${py0.length})")
+
+    val walk0 = o.get("walk") match {
+      case None => None
+      case Some(j) => j.to[PixelWalk] match {
+        case Left(je) => return MYBAD(nid, sid, t, je.toString)
+        case Right(pw) => Some(pw)
+      }
+    }
+
+    val ptail = 
+      if ((px0 ne null) && (py0 ne null)) {
+        o.get("ptail").flatMap{_ match {
+          case jn: Json.Num if (jn.double.toInt == jn.double) => Some(jn.double.toInt)
+          case _ => return MYBAD(nid, sid, t, "ptail isn't an integer")
+        }}
+      }
+      else None
+
+    Right(datumFromValues(
+      nid, sid, t, finO > 0, ox, oy, finC > 0, cx0, cy0, x0, y0, px0, py0, walk0, ptail, o.filter((k,_) => k.startsWith("@"))
+    ))
   }
 }
 
 /** Class to specify multiple timepoints on a single animal.
-  * `x` and `y` values are relative to `cx` and `cy` values, if present, `ox` and `oy` otherwise.
+  * `xDatas` and `yDatas` are relative to `rxs` and `rys`.  `cxs` and `cys` are global whether or not
+  * `oxs` and `oys` were present.
   * If all values of `ox` and `oy` are the same, they may be specified by an array of length 1 to save space.
   */
 case class Data(
   nid: Double, sid: String,
   ts: Array[Double],
-  xs: Array[Array[Float]], ys: Array[Array[Float]],
+  xDatas: Array[Array[Float]], yDatas: Array[Array[Float]],
   cxs: Array[Double], cys: Array[Double],
-  oxs: Array[Double], oys: Array[Double],
+  oxs: Array[Double], oys: Array[Double], unarrayedOrigin: Boolean,
+  perims: Option[Array[PerimeterPoints]],
+  walks: Option[Array[PixelWalk]],
   custom: Json.Obj
+)(
+  val rxs: Array[Double], val rys: Array[Double]
 )
 extends HasId with AsJson {
   assert(
-    (ts ne null) && (xs ne null) && (ys ne null) && (cxs ne null) && (cys ne null) && (oxs ne null) && (oys ne null) &&
-    ts.length == xs.length &&
-    ts.length == ys.length &&
+    (ts ne null) && (xDatas ne null) && (yDatas ne null) &&
+    (cxs ne null) && (cys ne null) && (oxs ne null) && (oys ne null) && (rxs ne null) && (rys ne null) &&
+    ts.length == xDatas.length &&
+    ts.length == yDatas.length &&
     { cxs.length == ts.length || cxs.length == 0 } &&
     { oxs.length == ts.length || oxs.length == 1 || oxs.length == 0 } &&
     cxs.length == cys.length &&
     oxs.length == oys.length &&
+    ts.length == rxs.length &&
+    ts.length == rys.length &&
     { var i = 0
       var good = true
-      while (good && i < xs.length) {
-        good = (xs(i) ne null) && (ys(i) ne null) && xs(i).length == ys(i).length
+      while (good && i < xDatas.length) {
+        good = (xDatas(i) ne null) && (yDatas(i) ne null) && xDatas(i).length == yDatas(i).length
         i += 1
       }
       good
-    }
+    } &&
+    perims.forall(_.length == ts.length) &&
+    walks.forall(_.length == ts.length)
   )
 
-  private val isGlobalOffset = cxs.length == 0 && oxs.length == 1 && oxs(0).finite && oys(0).finite
-  private[this] val isAnyOffset = cxs.length > 0 || oxs.length > 0 || isGlobalOffset
-  private val globalOffsetX = if (oxs.length == 1) oxs(0) else 0.0
-  private val globalOffsetY = if (oys.length == 1) oys(0) else 0.0
+  def n: Int = ts.length
 
-  var originPolicy: Data.OriginPolicy = Data.OriginPolicy.Needed
+  def spineN(i: Int) = xDatas(i).length
 
-  private def computeDeltaCxy(): (Array[Double], Array[Double]) =
-    if (cxs.length == 0 || oxs.length == 0 || (oxs.length == 1 && !(oxs(0).finite && oys(1).finite))) (cxs, cys)
-    else {
-      var dcx, dcy = new Array[Double](ts.length)
-      var i = 0
-      if (oxs.length == 1) {
-        while (i < dcx.length) {
-          dcx(i) = cxs(i) - globalOffsetX
-          dcy(i) = cys(i) - globalOffsetY
-          i += 1
-        }
-      }
-      else {
-        while (i < dcx.length) {
-          if (oxs(i).finite && oys(i).finite) {
-            dcx(i) = cxs(i) - oxs(i)
-            dcy(i) = cys(i) - oys(i)
-          }
-          i += 1
-        }        
-      }
-      (dcx, dcy)
+  def x(i: Int, j: Int) = xDatas(i)(j) + rxs(i)
+
+  def y(i: Int, j: Int) = yDatas(i)(j) + rys(i)
+
+  def spinePoints(i: Int): (Array[Double], Array[Double]) = {
+    val m = spineN(i)
+    val xs, ys = new Array[Double](m)
+    val xi = xDatas(i)
+    val yi = yDatas(i)
+    val rxi = rxs(i)
+    val ryi = rys(i)
+    var j = 0
+    while (j < m) {
+      xs(j) = xi(j) + rxi
+      ys(j) = yi(j) + ryi
+      j += 1
     }
+    (xs, ys)
+  }
 
-  /** spine x in global coordinates, point by point */
-  def gx(i: Int, j: Int) =
-    if (isAnyOffset)
-      xs(i)(j) + (
-        if (cxs.length > 0) cxs(i)
-        else if (isGlobalOffset) globalOffsetX
-        else oxs(i)
-      )
-    else xs(i)(j)
+  val myPerims: Array[Perimeter] = {
+    val mps = new Array[Perimeter](ts.length)
+    (perims, walks) match {
+      case (None, None)         => var i = 0; while (i < mps.length) { mps(i) = NoPerimeter; i += 1 }
+      case (Some(ps), None)     => var i = 0; while (i < mps.length) { mps(i) = ps(i); i += 1 }
+      case (None, Some(pw))     => var i = 0; while (i < mps.length) { mps(i) = pw(i); i += 1 }
+      case (Some(ps), Some(pw)) => var i = 0; while (i < mps.length) { mps(i) = if (ps(i).size == 0) pw(i) else ps(i); i += 1 }
+    }
+    mps
+  }
 
-  /** spine y in global coordinates, point by point */
-  def gy(i: Int, j: Int) =
-    if (isAnyOffset)
-      ys(i)(j) + (
-        if (cys.length > 0) cys(i)
-        else if (isGlobalOffset) globalOffsetY
-        else oys(i)
-      )
-    else ys(i)(j)
+  def perimN(i: Int) = myPerims(i).size
 
-  /** Entire spine x, in global coordinates */
-  def gxs(i: Int): Array[Double] =
-    if (!isAnyOffset) Data.doubly(xs(i))
-    else (Data.doubly(xs(i), if (cxs.length > 0) cxs(i) else if (isGlobalOffset) globalOffsetY else oxs(i)))
+  def px(i: Int, j: Int) = ???
 
-  /** Entire spine y, in global coordinates */
-  def gys(i: Int): Array[Double] =
-    if (!isAnyOffset) Data.doubly(ys(i))
-    else (Data.doubly(ys(i), if (cys.length > 0) cys(i) else if (isGlobalOffset) globalOffsetY else oys(i)))
+  def py(i: Int, j: Int) = ???
+
+  def perimPoints(i: Int): (Array[Double], Array[Double]) = myPerims(i).getPoints()
+
+  def datum(i: Int): Datum = new Datum(
+    nid, sid, ts(i), xDatas(i), yDatas(i),
+    if (cxs.length == 0) Double.NaN else cxs(i),
+    if (cys.length == 0) Double.NaN else cys(i),
+    if (oxs.length == 0) Double.NaN else if (oxs.length == 1) oxs(0) else oxs(i),
+    if (oys.length == 0) Double.NaN else if (oys.length == 1) oys(0) else oys(i),
+    perims.flatMap(pms => if (pms(i).size == 0) None else Some(pms(i))),
+    walks.flatMap(pws => if (pws(i).size == 0) None else Some(pws(i))),
+    custom
+  )(rxs(i), rys(i))
+
+  private def externalize(coords: Array[Float], r: Double, has: Boolean, oc: Double): Array[Double] = {
+    val ext = new Array[Double](coords.length)
+    val delta = r - (if (has) oc else 0.0)
+    var i = 0
+    while (i < ext.length) {
+      ext(i) = Data.sig(coords(i) + delta)
+      i += 1
+    }
+    ext
+  }
 
   def json = {
-    val b = Json ~ ("id", idJSON) ~ ("t", ts)
-    val dxs = Data.doubly(xs)
-    val dys = Data.doubly(ys)
-    originPolicy match {
-      case Data.OriginPolicy.Needed =>
-        if (cxs.length > 0) b ~ ("cx", cxs) ~ ("cy", cys)
-        else if (oxs.length > 0) b ~ ("ox", oxs) ~ ("oy", oys)
-      case Data.OriginPolicy.Always =>
-        if (oxs.length > 0) {
-          if (cxs.length > 0) {
-            val (fixedCxs, fixedCys) = computeDeltaCxy()
-            b ~ ("cx", fixedCxs) ~ ("cy", fixedCys)
-          }
-          b ~ ("ox", oxs) ~ ("oy", oys)
-        }
-        else if (cxs.length > 0) {
-          val zeros = new Array[Double](oxs.length)
-          b ~ ("cx", zeros) ~ ("cy", zeros) ~ ("ox", cxs) ~ ("oy", cys)
-        }
-        else {
-          val ax, ay = new Array[Double](ts.length)
-          var i = 0
-          while (i < ax.length) {
-            val dxsi = dxs(i)
-            val dysi = dys(i)
-            var qx, qy = 0.0
-            var n, j = 0
-            while (j < dxsi.length) {
-              if (dxsi(j).finite && dysi(j).finite) {
-                n += 1
-                qx += dxsi(j)
-                qy += dysi(j)
-              }
-              j += 1
-            }
-            if (n > 0) {
-              qx /= n
-              qy /= n
-              j = 0
-              while (j < dxsi.length) {
-                if (dxsi(j).finite) dxsi(j) -= qx
-                if (dysi(j).finite) dysi(j) -= qy
-                j += 1
-              }
-            }
-            ax(i) = qx
-            ay(i) = qy
-            i += 1
-          }
-          b ~ ("ox", ax) ~ ("oy", ay)
-        }
-      case Data.OriginPolicy.Never =>
-        var i = 0
-        if (oxs.length > 0) {
-          if (cxs.length > 0) {
-            val (fixedCxs, fixedCys) = computeDeltaCxy()
-            b ~ ("cx", fixedCxs) ~ ("cy", fixedCys)
-            while (i < dxs.length) {
-              if (!(cxs(i).finite && cys(i).finite) && oxs(i).finite && oys(i).finite) {
-                val x0 = oxs(i)
-                val y0 = oys(i)
-                val dxsi = dxs(i)
-                val dysi = dys(i)
-                var j = 0
-                while (j < dxsi.length) { dxsi(j) += x0; dysi(j) += y0; j += 1 }
-              }
-            }
-          }
-          else {
-            while (i < dxs.length) {
-              if (isGlobalOffset || (oxs(i).finite && oys(i).finite)) {
-                val x0 = if (isGlobalOffset) globalOffsetX else oxs(i)
-                val y0 = if (isGlobalOffset) globalOffsetY else oys(i)
-                val dxsi = dxs(i)
-                val dysi = dys(i)
-                var j = 0
-                while (j < dxsi.length) { dxsi(j) += x0; dysi(j) += y0; j += 1 }
-              }
-            }
-          }
-        }
-        else if (cxs.length > 0) b ~ ("cx", cxs) ~ ("cy", cys)
+    val b = Json ~ ("id", idJSON) ~ ("t", Json(ts))
+    if (oxs.length > 0) {
+      if (oxs.length == 1 && unarrayedOrigin) b ~ ("ox", oxs(0)) ~ ("oy", oys(0))
+      else b ~ ("ox", Json(oxs)) ~ ("oy", Json(oys))
     }
-    b ~ ("x", dxs) ~ ("y", dys) ~~ custom ~ Json
+    if (cxs.length > 0) {
+      val kxs =
+        if (oxs.length == 0 || (oxs.length == 1 && oxs(0) == 0)) cxs
+        else {
+          var qs = new Array[Double](cxs.length)
+          if (oxs.length == 1) { var i = 0; while (i < cxs.length) { qs(i) = Data.sig(cxs(i) - oxs(0)); i += 1 } }
+          else                 { var i = 0; while (i < cxs.length) { qs(i) = Data.sig(cxs(i) - oxs(i)); i += 1 } }
+          qs
+        }
+      val kys =
+        if (oys.length == 0 || (oys.length == 1 && oys(0) == 0)) cys
+        else {
+          var qs = new Array[Double](cys.length)
+          if (oys.length == 1) { var i = 0; while (i < cys.length) { qs(i) = Data.sig(cys(i) - oys(0)); i += 1 } }
+          else                 { var i = 0; while (i < cys.length) { qs(i) = Data.sig(cys(i) - oys(i)); i += 1 } }
+          qs
+        }
+      b ~ ("cx", Json(kxs)) ~ ("cy", Json(kys))
+    }
+    val dxs = ts.indices.map{ i =>
+      val oi = if (oxs.length > 0) { if (oxs.length == 1) oxs(0) else oxs(i) } else 0.0
+      val has = (oxs.length > 0) && !oi.isNaN
+      externalize(xDatas(i), rxs(i), has, oi)
+    }
+    val dys = ts.indices.map{ i =>
+      val oi = if (oys.length > 0) { if (oys.length == 1) oys(0) else oys(i) } else 0.0
+      val has = (oys.length > 0) && !oi.isNaN
+      externalize(yDatas(i), rys(i), has, oi)
+    }
+    b ~ ("x", Json(dxs)) ~ ("y", Json(dys))
+    if (perims.isDefined) {
+      val pms = perims.get
+      val pxs = ts.indices.map{ i =>
+        val oi = if (oxs.length > 0) { if (oxs.length == 1) oxs(0) else oxs(i) } else 0.0
+        val has = (oxs.length > 0 ) && !oi.isNaN
+        externalize(pms(i).xData, pms(i).rx, has, oi)
+      }
+      val pys = ts.indices.map{ i =>
+        val oi = if (oys.length > 0) { if (oys.length == 1) oys(0) else oys(i) } else 0.0
+        val has = (oys.length > 0) && !oi.isNaN
+        externalize(pms(i).yData, pms(i).ry, has, oi)
+      }
+      b ~ ("px", Json(pxs)) ~ ("py", Json(pys))
+      if (pms.exists(_.tailIndex.isDefined)) {
+        val tis = new Array[Double](n)
+        var i = 0; while (i < tis.length) { tis(i) = pms(i).tailIndex match { case Some(i) => i.toDouble; case _ => Double.NaN }; i += 1 }
+        i = 1; while (i < tis.length && tis(i) == tis(i-1)) i += 1
+        if (i == tis.length) b ~ ("ptail", tis(0))
+        else b ~ ("ptail", Json(tis))
+      }
+    }
+    b ~? ("walk", walks) ~~ custom ~ Json
   }
 
   override def toString = json.toString
@@ -381,7 +558,7 @@ extends HasId with AsJson {
   def similarTo(d: Data, tol: Double): Boolean = similarTo(d, tol, true)
 
   def similarTo(d: Data, tol: Double, checkCentroids: Boolean): Boolean =
-    (ts.length == d.ts.length) &&
+    (n == d.n) &&
     { var i = 0
       var close = true
       while (i < ts.length && close) {
@@ -390,29 +567,22 @@ extends HasId with AsJson {
       }
       close
     } &&
-    (cxs.length == d.cxs.length || !checkCentroids) &&
     { var i = 0
       var close = true
       if (checkCentroids) while (i < cxs.length && close) {
-        close = math.abs(cxs(i) - d.cxs(i)) + math.abs(cys(i) - d.cys(i)) <= 2*tol
+        close = math.abs(cxs(i) - d.cxs(i)) < tol && math.abs(cys(i) - d.cys(i)) <= tol
         i += 1
       }
       close
     } &&
-    (xs.length == d.xs.length) &&
     { var i = 0
       var close = true
-      while (i < xs.length && close) {
-        close = xs(i).length == d.xs(i).length
-        val dX =
-          (if (cxs.length > 0) cxs(i) else if (oxs.length > 1) oxs(i) else globalOffsetX) -
-          (if (d.cxs.length > 0) d.cxs(i) else if (d.oxs.length > 1) d.oxs(i) else d.globalOffsetX)
-        val dY =
-          (if (cys.length > 0) cys(i) else if (oys.length > 1) oys(i) else globalOffsetY) -
-          (if (d.cys.length > 0) d.cys(i) else if (d.oys.length > 1) d.oys(i) else d.globalOffsetY)
+      while (i < n && close) {
+        close = spineN(i) == d.spineN(i)
+        val jN = spineN(i)
         var j = 0
-        while (j < xs(i).length && close) {
-          close = math.abs(xs(i)(j) - d.xs(i)(j) + dX) + math.abs(ys(i)(j) - d.ys(i)(j) + dY) <= 2*tol
+        while (j < jN && close) {
+          close = math.abs(x(i, j) - d.x(i, j)) < tol && math.abs(y(i, j) - d.y(i, j)) < tol
           j += 1
         }
         i += 1
@@ -421,6 +591,10 @@ extends HasId with AsJson {
     }
 }
 object Data extends FromJson[Data] {
+  def sig(x: Double): Double =
+    if (x < -1e9 || x > 1e9) x
+    else math.rint(x*1e5).toLong/1e5
+
   def doubly(xs: Array[Float]): Array[Double] = {
     var qs = new Array[Double](xs.length)
     var i = 0
@@ -458,28 +632,6 @@ object Data extends FromJson[Data] {
     qss
   }
 
-  def findFloatOffsets(zss: Array[Array[Double]]): Array[Double] = {
-    val ans = new Array[Double](zss.length)
-    var i = 0
-    while (i < ans.length) {
-      var minz, maxz = Double.NaN
-      val zs = zss(i)
-      var j = 0
-      while (j < zs.length) {
-        val z = zs(j)
-        if (z.finite) {
-          if (!(z >= minz)) minz = z
-          if (!(z <= maxz)) maxz = z
-        }
-        j += 1
-      }
-      val oz = (minz + maxz)*0.5;
-      ans(i) = if (oz.finite) oz else 0.0;
-      i += 1
-    }
-    ans
-  }
-
   private def BAD(msg: String): Either[JastError, Nothing] = Left(JastError("Invalid data entries: " + msg))
   private def IBAD(nid: Double, sid: String, msg: String): Either[JastError, Nothing] =
     BAD("Data points for " + IdOnly(nid,sid).idJSON.json + " have " + msg)
@@ -490,25 +642,21 @@ object Data extends FromJson[Data] {
   private[trackercommons] val zeroD = Array(0.0)
   private[trackercommons] val emptyFF = new Array[Array[Float]](0)
 
-  val empty = new Data(Double.NaN, "", emptyD, emptyFF, emptyFF, emptyD, emptyD, emptyD, emptyD, Json.Obj.empty)
+  val empty = new Data(
+    Double.NaN, "", emptyD, emptyFF, emptyFF, emptyD, emptyD, emptyD, emptyD, false, None, None, Json.Obj.empty
+  )(emptyD, emptyD)
 
-  sealed trait OriginPolicy {}
-  object OriginPolicy {
-    case object Never extends OriginPolicy {}
-    case object Needed extends OriginPolicy {}
-    case object Always extends OriginPolicy {}
-  }
-
-  private val someSingles = Option(Set("id", "t", "x", "y", "cx", "cy", "ox", "oy"))
+  private val someSingles = Option(Set("id", "t", "x", "y", "cx", "cy", "ox", "oy", "px", "py", "ptail", "walk"))
 
   def parse(j: Json): Either[JastError, Data] = {
+    implicit val pixelwalkFromJson: FromJson[PixelWalk] = PixelWalk
+
     val o = j match {
       case jo: Json.Obj => jo
       case _ => return BAD("not a JSON object")
     }
     o.countKeys(someSingles).foreach{ case (key, n) => if (n > 1) return BAD("duplicate entries for " + key) }
 
-    var numO = 0
     var numC = 0
     val (nid, sid) = o("id") match {
       case Json.Null => (Double.NaN, null: String)
@@ -520,10 +668,12 @@ object Data extends FromJson[Data] {
       case ja: Json.Arr.Dbl => ja.doubles
       case _ => return BAD("no time array!")
     }
-    val List(ox0, oy0) = List("ox", "oy").map(key => o.get(key) match {
+    var numO = 0
+    var unarr = false
+    val List(ox, oy) = List("ox", "oy").map(key => o.get(key) match {
       case None => emptyD
       case Some(j) => j match {
-        case n: Json.Num => Array(n.double)
+        case n: Json.Num => unarr = true; Array(n.double)
         case ja: Json.Arr.Dbl => 
           if (ja.size != 1 && ja.size != t.length)
              return IBAD(nid, sid, f"$key array size does not match time series size!") 
@@ -532,8 +682,9 @@ object Data extends FromJson[Data] {
         case _ => return IBAD(nid, sid, f"non-numeric $key origin")
       }
     })
-    var ox = ox0
-    var oy = oy0
+    if (ox.length != oy.length) IBAD(nid, sid, "ox and oy sizes do not match")
+    if (numO == 1) return IBAD(nid, sid, "only one of ox, oy: include both or neither!")
+
     val List(cx, cy) = List("cx", "cy").map(key => o.get(key) match {
       case None => emptyD
       case Some(j) => j match {
@@ -544,93 +695,105 @@ object Data extends FromJson[Data] {
         case _=> return IBAD(nid, sid, f"non-numeric or improperly shaped $key")
       }
     })
-    if (numO == 1) return IBAD(nid, sid, "only one of ox, oy: include both or neither!")
     if (numC == 1) return IBAD(nid, sid, "only one of cx, cy: include both or neither!")
-    val List(x, y) = List(("x", cx, ox), ("y", cy, oy)).map{ case (key, c, ori) => o(key) match {
-        case Json.Null =>
-          if (c.length == 0) return IBAD(nid, sid, f"no $key!")
-          else if (ori.length == 0) Array.fill(c.length)(zeroD)
-          else c.map(x => Array(x))
-        case n: Json.Num =>
-          if (t.length != 1) return IBAD(nid, sid, f"$key size does not match time series size!")
-          Array(Array(n.double))
-        case ja: Json.Arr.Dbl => 
-          if (t.length == 1) Array(ja.doubles)
-          else if (t.length == ja.size) ja.doubles.map(x => Array(x))
-          else return IBAD(nid, sid, f"$key size does not match time series size!")
-        case jall: Json.Arr.All =>
-          if (jall.size != t.length) return IBAD(nid, sid, f"$key size does not match time series size!")
-          jall.values.map(_ match {
-            case Json.Null => emptyD
-            case n: Json.Num => Array(n.double)
-            case ja: Json.Arr.Dbl => ja.doubles
-            case _ => return IBAD(nid, sid, f"$key has non-numeric data elements!")
-          }) 
-        case _ => return IBAD(nid, sid, f"non-numeric or improperly shaped $key")
+
+    val List((x0, px0), (y0, py0)) =
+      List(("x", "px"), ("y", "py")).map{ case (key, peri) =>
+        val ans =
+          List(key, peri).map{ kk => o.get(kk) match {
+            case None => if (kk.startsWith("p")) null else return IBAD(nid, sid, f"no $key!")
+            case Some(j) => j match {
+              case Json.Null => 
+                if (kk.startsWith("p")) null
+                else return IBAD(nid, sid, f"no $key!")
+              case n: Json.Num =>
+                if (t.length != 1) return IBAD(nid, sid, f"$key size does not match time series size!")
+                Array(Array(n.double))
+              case ja: Json.Arr.Dbl => 
+                if (t.length == 1) Array(ja.doubles)
+                else if (t.length == ja.size) ja.doubles.map(x => Array(x))
+                else return IBAD(nid, sid, f"$key size does not match time series size!")
+              case jall: Json.Arr.All =>
+                if (jall.size != t.length) return IBAD(nid, sid, f"$key size does not match time series size!")
+                jall.values.map(_ match {
+                  case Json.Null => emptyD
+                  case n: Json.Num => Array(n.double)
+                  case ja: Json.Arr.Dbl => ja.doubles
+                  case _ => return IBAD(nid, sid, f"$key has non-numeric data elements!")
+                })
+              case _ => return IBAD(nid, sid, f"non-numeric or improperly shaped $key")          
+            }
+          }}
+        (ans.head, ans.tail.head)
       }
-    }
+    if ((px0 eq null) != (py0 eq null)) return IBAD(nid, sid, "Only one of px or py present")
     var i = 0
-    while (i < x.length) {
-      if (x(i).length != y(i).length) return MYBAD(nid, sid, t(i), "mismatch in x and y sizes!")
+    while (i < x0.length) {
+      if (x0(i).length != y0(i).length) return MYBAD(nid, sid, t(i), "mismatch in x and y sizes!")
+      if ((px0 ne null) && px0(i).length != py0(i).length) return MYBAD(nid, sid, t(i), "mismatch in px and py sizes!")
       i += 1
     }
-    if (ox.length > 0 && cx.length > 0) {
-      if (ox.length == 1) { var i = 0; while (i < cx.length) { cx(i) += ox(0); i += 1 } }
-      else { var i = 0; while (i < cx.length) { cx(i) += ox(i); i +=1 } }
+
+    val walk0 = o.get("walk") match {
+      case None => None
+      case Some(j) => j match {
+        case jaa: Json.Arr.All if jaa.size == t.length =>
+          val pws = new Array[PixelWalk](t.length)
+          var i = 0
+          while (i < pws.length) {
+            pws(i) = jaa(i) match {
+              case Json.Null => PixelWalk.empty
+              case j         => j.to[PixelWalk] match {
+                case Right(pw) => pw
+                case Left(je) => return MYBAD(nid, sid, t(i), "Can't read walk: " + je.toString)
+              }
+            }
+          }
+          Some(pws)
+        }
     }
-    if (oy.length > 0 && cy.length > 0) {
-      if (oy.length == 1) { var i = 0; while (i < cy.length) { cy(i) += oy(0); i += 1 } }
-      else { var i = 0; while (i < cy.length) { cy(i) += oy(i); i +=1 } }
-    }
+
+    val ptail: Option[Array[Int]] = 
+      if ((px0 ne null) && (py0 ne null)) {
+        o.get("ptail").flatMap{_ match {
+          case Json.Null => None
+          case jn: Json.Num if (jn.double.toInt == jn.double) => Some(Array.fill(t.length)(jn.double.toInt))
+          case jad: Json.Arr.Dbl if jad.size == t.length => Some(jad.doubles.map(d =>
+              if (d.isNaN) -1
+              else if (d.toInt == d && d >= 0) d.toInt
+              else return IBAD(nid, sid, "ptail isn't an appropriate number of integers") 
+            ))
+          case _ => return IBAD(nid, sid, "ptail isn't an appropriate number of integers")
+        }}
+      }
+      else None
+
+    val x, y = new Array[Array[Float]](t.length)
+    val rx, ry = new Array[Double](t.length)
+    val pms = if (px0 ne null) new Array[PerimeterPoints](t.length) else null
     i = 0
-    /*
-    if (ox.length == 0 && cx.length == 0) {
-      var tentox, tentoy = new Array[Double](x.length)
-      var fracerrsq = 0.0
-      var i = 0
-      while (i < x.length) {
-        var j = 0
-        var myminx, mymaxx, myminy, mymaxy = Double.NaN
-        var e = 0.0
-        while (j < x(i).length) {
-          val xij = x(i)(j)
-          val yij = y(i)(j)
-          if (xij.finite) {
-            if (!(myminx.finite && myminx <= xij)) myminx = xij
-            if (!(mymaxx.finite && mymaxx >= xij)) mymaxx = xij
-          }
-          if (yij.finite) {
-            if (!(myminy.finite && myminy <= yij)) myminy = yij
-            if (!(mymaxy.finite && mymaxy >= yij)) mymaxy = yij
-          }
-          if (xij.finite && yij.finite) e = math.max(e, math.max(math.abs(xij - xij.toFloat), math.abs(yij - yij.toFloat)))
-          j += 1
-        }
-        var sepsq = 0.0
-        if (myminx.finite && mymaxx.finite) {
-          val aminx = math.abs(myminx)
-          val amaxx = math.abs(mymaxx)
-          val dx = mymaxx - myminx
-          tentox(i) = if (dx < 2*math.min(aminx, amaxx)) (myminx + mymaxx)*0.5 else 0.0
-          sepsq += dx*dx
-        }
-        else tentox(i) = 0.0
-        if (myminy.finite && mymaxy.finite) {
-          val aminy = math.abs(myminy)
-          val amaxy = math.abs(mymaxy)
-          val dy = mymaxy - myminy
-          tentoy(i) = if (dy < 2*math.min(aminy, amaxy)) (myminy + mymaxy)*0.5 else 0.0
-          sepsq += dy*dy
-        }
-        if (sepsq > 0) fracerrsq = math.max(fracerrsq, (e*e) / sepsq)
-        i += 1
-      }
-      if (fracerrsq > 1e-6) {
-        ox = tentox
-        oy = tentoy
-      }
+    while (i < x.length) {
+      val oxi = if (ox.length < 1) Double.NaN else if (ox.length == 1) ox(0) else ox(i)
+      val oyi = if (oy.length < 1) Double.NaN else if (oy.length == 1) oy(0) else oy(i)
+      val datumi = Datum.datumFromValues(
+        nid, sid, t(i),
+        ox.length > 0, oxi, oyi,
+        cx.length > 0, if (cx.length > 0) cx(i) else Double.NaN, if (cy.length > 0) cy(i) else Double.NaN,
+        x0(i), y0(i),
+        if (px0 eq null) null else px0(i), if (py0 eq null) null else py0(i),
+        walk0.map(_(i)), ptail.flatMap(p => if (p(i) < 0) None else Some(p(i))),
+        Json.Obj.empty
+      )
+      if (cx.length > 0) cx(i) = datumi.cx
+      if (cy.length > 0) cy(i) = datumi.cy
+      x(i) = datumi.xData
+      y(i) = datumi.yData
+      rx(i) = datumi.rx
+      ry(i) = datumi.ry
+      datumi.walk.foreach(w => walk0.get(i) = w)
+      if (pms ne null) pms(i) = datumi.perim.get
+      i += 1
     }
-    */
-    Right(new Data(nid, sid, t, Data.singly(x), Data.singly(y), cx, cy, ox, oy, o.filter((k,_) => k.startsWith("@"))))
+    Right(new Data(nid, sid, t, x, y, cx, cy, ox, oy, unarr, Option(pms), walk0, o.filter((k,_) => k.startsWith("@")))(rx, ry))
   }
 }

--- a/src/scala/src/main/scala/DataSet.scala
+++ b/src/scala/src/main/scala/DataSet.scala
@@ -11,104 +11,44 @@ extends AsJson {
   def json = unitmap.unfix(
     Json
     ~ ("units", unitmap)
-    ~ ("data", data.map(e => Json either e))
+    ~ ("data", Json(data.map(e => Json either e)))
     ~? ("metadata", if (meta == Metadata.empty) None else Some(meta))
     ~? ("files", if (files == FileSet.empty) None else Some(files))
-    ~~ custom ~ Json
+    ~~ custom
+    ~ Json,
+    DataSet.convertedParts
   )
-
-  def combined(
-    combiner: collection.Map[String, (Array[List[Json]], Array[Array[Double]]) => Option[List[Json]]] = Map.empty
-  ): Either[String, Array[Data]] = {
-    Right(data.
-      map{ case Right(x) => x; case Left(x) => x.toData }.
-      groupBy(_.idEither).
-      iterator.map(_._2.filter(_.ts.length > 0).sortBy(_.ts(0))).filter(_.length > 0).toArray.
-      map{ datas =>
-        if (datas.length == 1) datas(0)
-        else {
-          for (i <- datas.indices.drop(1)) {
-            val l = datas(i-1)
-            val r = datas(i)
-            if (!(l.ts(l.ts.length-1) < r.ts(0))) return Left(s"Data timepoints overlap on animal ${l.idJSON} near t=${r.ts(0)}")
-          }
-          val ts = new Array[Double](datas.map(_.ts.length).sum)
-          val xs, ys = new Array[Array[Float]](ts.length)
-          val (cxs, cys) = 
-            if (datas.forall(_.cxs.length == 0)) (Data.emptyD, Data.emptyD)
-            else {
-              val a, b = new Array[Double](ts.length)
-              (a, b)
-            }
-          val (oxs, oys) =
-            if (datas.forall(_.oxs.length == 0)) (Data.emptyD, Data.emptyD)
-            else if (datas.forall(d => d.oxs.length == 1 && d.oxs(0) == datas(0).oxs(0) && d.oys(0) == datas(0).oys(0))) {
-              val a, b = new Array[Double](1)
-              (a, b)
-            }
-            else {
-              val a, b = new Array[Double](ts.length)
-              (a, b)
-            }
-          var i = 0
-          if (oxs.length == 1) {
-            oxs(0) = datas(0).oxs(0)
-            oys(0) = datas(0).oxs(0)
-          }
-          for (data <- datas) {
-            System.arraycopy(data.ts, 0, ts, i, data.ts.length)
-            System.arraycopy(data.xs, 0, xs, i, data.xs.length)
-            System.arraycopy(data.ys, 0, ys, i, data.ys.length)
-            if (cxs.length > 0) {
-              if (data.cxs.length > 0) {
-                System.arraycopy(data.cxs, 0, cxs, i, data.cxs.length)
-                System.arraycopy(data.cys, 0, cys, i, data.cys.length)                              
-              }
-              else {
-                java.util.Arrays.fill(cxs, i, i + data.ts.length, Double.NaN)
-                java.util.Arrays.fill(cys, i, i + data.ts.length, Double.NaN)
-              }
-            }
-            if (oxs.length > 0) {
-              if (data.oxs.length > 0) {
-                System.arraycopy(data.oxs, 0, oxs, i, data.oxs.length)
-                System.arraycopy(data.oys, 0, oys, i, data.oys.length)
-              }
-              else {
-                java.util.Arrays.fill(oxs, i, i + data.ts.length, 0.0)
-                java.util.Arrays.fill(oys, i, i + data.ts.length, 0.0)
-              }
-            }
-            i += data.ts.length
-          }
-          val labels = collection.mutable.Set.empty[String]
-          for { data <- datas } data.custom.foreach{ (k,_) => labels += k }
-          labels.toArray.foreach{ key => if (!(combiner contains key)) labels -= key }
-          val custom =
-            if (labels.isEmpty) Json.Obj.empty
-            else throw new UnsupportedOperationException("Cannot merge custom labels.")
-          Data(datas(0).nid, datas(0).sid, ts, xs, ys, cxs, cys, oxs, oys, custom)
-        }
-      }
-    )
-  }
 }
 object DataSet extends FromJson[DataSet] {
   def apply(meta: Metadata, unitmap: UnitMap, data: Array[Data], files: FileSet = FileSet.empty, custom: Json.Obj = Json.Obj.empty): DataSet =
     new DataSet(meta, unitmap, data.map(x => Right(x)), files, custom)
 
+  val convertedParts = UnitMap.Nested(Map(
+    ("files", UnitMap.OnlyCustom),
+    ("data", UnitMap.OnlyCustom),
+    ("metadata", UnitMap.Leaves(Set(
+      "lab", "arena", "software"
+    )))
+  ))
+
   def parse(j: Json): Either[JastError, DataSet] = {
     implicit val parseDatum: FromJson[Datum] = Datum
     implicit val parseData: FromJson[Data] = Data
 
-    val o = j match { 
-      case jo: Json.Obj => jo
+    val (o, u) = j match { 
+      case jo: Json.Obj =>
+        val ux = jo("units").to(UnitMap) match {
+          case Right(x) => x
+          case Left(e) => return Left(JastError("Error parsing units in WCON data set", because = e))
+        }
+        val jx = ux.fix(jo, convertedParts) match {
+          case x: Json.Obj => x
+          case _           => return Left(JastError("Did not get a JSON object after unit converting a JSON object???"))
+        }
+        (jx, ux)
       case _ => return Left(JastError("Not a JSON object so not a WCON data set"))
     }
-    val u = o("units").to(UnitMap) match {
-      case Right(x) => x
-      case Left(e) => return Left(JastError("Error parsing units in WCON data set", because = e))
-    }
+    
     val d = o("data").to[Array[Either[Datum, Data]]] match {
       case Right(x) => x
       case Left(e) => return Left(JastError("Error parsing data in WCON data set", because = e))

--- a/src/scala/src/main/scala/DataSet.scala
+++ b/src/scala/src/main/scala/DataSet.scala
@@ -25,10 +25,8 @@ object DataSet extends FromJson[DataSet] {
 
   val convertedParts = UnitMap.Nested(Map(
     ("files", UnitMap.OnlyCustom),
-    ("data", UnitMap.OnlyCustom),
-    ("metadata", UnitMap.Leaves(Set(
-      "lab", "arena", "software"
-    )))
+    ("data", UnitMap.Leaves(Set("walk"))),
+    ("metadata", UnitMap.Leaves(Set("lab", "arena", "software")))
   ))
 
   def parse(j: Json): Either[JastError, DataSet] = {

--- a/src/scala/src/main/scala/UnitMap.scala
+++ b/src/scala/src/main/scala/UnitMap.scala
@@ -8,50 +8,146 @@ case class UnitMap(lookup: Map[String, units.Convert], custom: Json.Obj) extends
   val json = Json ~~ lookup ~~ custom ~~ Json
   def has(s: String) = lookup contains s
   def missing(s: String) = !(lookup contains s)
-  // These are duplicated for speed.
-  private def renumF(n: Json.Num, u: units.Convert): Json = {
+
+  private def renum(n: Json.Num, u: units.Convert, from: Boolean): Json = {
     val x = n.double
-    val y = x from u
+    val y = if (from) x from u else x into u
     if (x == y || x.isNaN) n else Json.Num(y)
   }
-  private def renumU(n: Json.Num, u: units.Convert): Json = {
-    val x = n.double
-    val y = x into u
-    if (x == y || x.isNaN) n else Json.Num(y)
-  }
+
+  private def convert(j: Json, into: UnitMap.Into, u: units.Convert, from: Boolean): Json =
+    j match {
+      case o: Json.Obj =>
+        if (o.isArrayBacked) {
+          val kva = o.asFlatArray
+          var a: Array[AnyRef] = null
+          var j = 0
+          var i = 0
+          var same = true
+          while (same && i+1 < kva.length) {
+            val ki = kva(i).asInstanceOf[String]
+            val vi = kva(i+1).asInstanceOf[Json]
+            val wi = into(ki) match {
+              case Some(in) =>
+                val ui = lookup.getOrElse(ki, u)
+                convert(vi, in, ui, from)
+              case _ =>
+                lookup.get(ki) match {
+                  case Some(ui) => convert(vi, UnitMap.Nowhere, ui, from)
+                  case _        => vi
+                }
+            }
+            if (wi ne vi) {
+              same = false
+              a = new Array[AnyRef](kva.length)
+              while (j < i) { a(j) = kva(j); j += 1 }
+              a(j) = ki
+              a(j+1) = wi
+              j += 2
+            }
+            i += 2
+          }
+          if (j != 0) {
+            while (j+1 < kva.length) {
+              val kj = kva(j).asInstanceOf[String]
+              a(j) = kj
+              val vj = kva(j+1).asInstanceOf[Json]
+              a(j+1) = into(kj) match {
+                case Some(in) =>
+                  val uj = lookup.getOrElse(kj, u)
+                  convert(vj, in, uj, from)
+                case _ =>
+                  lookup.get(kj) match {
+                    case Some(uj) => convert(vj, UnitMap.Nowhere, uj, from)
+                    case _        => vj
+                  }
+              }
+              j += 2
+            }
+            Json.Obj fromFlatArray a
+          }
+          else o
+        }
+        else {
+          var transformed = false
+          val oo = o.transformValues{ (ki, vi) =>
+            val wi = into(ki) match {
+              case Some(in) =>
+                val ui = lookup.getOrElse(ki, u)
+                convert(vi, in, ui, from)
+              case _ =>
+                lookup.get(ki) match {
+                  case Some(ui) => convert(vi, UnitMap.Nowhere, ui, from)
+                  case _        => vi
+                }
+            }              
+            if (wi ne vi) transformed = true
+            wi
+          }
+          if (transformed) oo else o
+        }
+      case jaa: Json.Arr.All =>
+        var a: Array[Json] = null
+        var j = 0
+        var i = 0
+        var same = true
+        while (same && i < jaa.values.length) {
+          val ji = jaa.values(i)
+          val ki = convert(ji, into, u, from)
+          if (ki ne ji) {
+            same = false
+            a = new Array[Json](jaa.values.length)
+            while (j < i) { a(j) = jaa.values(j); j += 1 }
+            a(j) = ki
+            j += 1
+          }
+          i += 1
+        }
+        if (j != 0) {
+          while (j < jaa.values.length) {
+            a(j) = convert(jaa.values(j), into, u, from)
+            j += 1
+          }
+          Json.Arr.All(a)
+        }
+        else jaa
+      case x if u eq null =>
+        x
+      case n: Json.Num =>
+        renum(n, u, from)
+      case jad: Json.Arr.Dbl =>
+        val a = java.util.Arrays.copyOf(jad.doubles, jad.doubles.length)
+        if (from) a changeFrom u else a changeInto u
+        var i = 0; while (i < a.length && jad.doubles(i) == a(i)) i += 1
+        if (i == a.length) jad else Json.Arr.Dbl(a)
+      case y =>
+        y
+    }
+
   // Note -- we need to go in both directions to take advantage of floating point division
   // being more accurate than multiplication by the reciprocal
-  def fix(j: Json, known: Option[units.Convert] = None): Json = {
-    j match {
-      case n: Json.Num => known match { case Some(u) => renumF(n, u); case None => n }
-      case jad: Json.Arr.Dbl => known match { case Some(u) => jad.doubles changeFrom u; case None => }; jad
-      case jaa: Json.Arr.All => 
-        val a = jaa.values   // Will mutate underlying array directly
-        var i = 0
-        while (i < a.length) { val j = fix(a(i), known); if (a(i) ne j) a(i) = j; i += 1 }
-        jaa
-      case o: Json.Obj => o.transformValues{ (k,v) => fix(v, lookup.get(k) orElse known) }
-      case _ =>
-    }
-    j
-  }
-  def unfix(j: Json, known: Option[units.Convert] = None): Json = {
-    j match {
-      case n: Json.Num => known match { case Some(u) => renumU(n, u); case None => n }
-      case jad: Json.Arr.Dbl => known match { case Some(u) => jad.doubles changeInto u; case None => }; jad
-      case jaa: Json.Arr.All => 
-        val a = jaa.values   // Will mutate underlying array directly
-        var i = 0
-        while (i < a.length) { val j = fix(a(i), known); if (a(i) ne j) a(i) = j; i += 1 }
-        jaa
-      case o: Json.Obj => o.transformValues{ (k,v) => fix(v, lookup.get(k) orElse known) }
-      case _ =>
-    }
-    j
-  }
+  def fix(j: Json, into: UnitMap.Into = UnitMap.OnlyCustom): Json = convert(j, into, null, true)
+  def unfix(j: Json, into: UnitMap.Into = UnitMap.OnlyCustom): Json = convert(j, into, null, false)
 }
 object UnitMap extends FromJson[UnitMap] {
   import units._
+
+  sealed trait Into { def apply(s: String): Option[Into] }
+  case object Nowhere extends Into { def apply(s: String) = None }
+  case object OnlyCustom extends Into {
+    lazy val asOption = Option(OnlyCustom)
+    def apply(s: String) = if (s.length > 0 && s.charAt(0) == '@') asOption else None
+  }
+  final case class Nested(these: Map[String, Into]) extends Into { 
+    def apply(s: String) = these.get(s) orElse OnlyCustom(s)
+  }
+  final case class Leaves(those: Set[String]) extends Into {
+    def apply(s: String) = if (those contains s) OnlyCustom.asOption else OnlyCustom(s)
+  }
+  final class Arbitrary(pf: PartialFunction[String, Into]) extends Into {
+    private val lifted = pf.lift
+    def apply(s: String) = lifted(s)
+  }
 
   val default = {
     import Standard._
@@ -61,6 +157,7 @@ object UnitMap extends FromJson[UnitMap] {
         "x" -> millimeter, "y" -> millimeter,
         "cx" -> millimeter, "cy" -> millimeter,
         "ox" -> millimeter, "oy" -> millimeter,
+        "px" -> millimeter, "py" -> millimeter,
         "age" -> hour,
         "temperature" -> celsius,
         "humidity" -> percent,

--- a/src/scala/src/main/scala/Units.scala
+++ b/src/scala/src/main/scala/Units.scala
@@ -8,6 +8,7 @@ package units {
     def name: String
     def toInternal(x: Double): Double
     def toExternal(x: Double): Double
+    def isIdentity: Boolean = false
 
     def json = Json.Str(name)
 
@@ -22,10 +23,17 @@ package units {
     def changeToExternal(fss: Array[Array[Float]]) { var i = 0; while (i < fss.length) { changeToExternal(fss(i)); i += 1 } }
   }
 
+  case class IdentityConvert(name: String) extends Convert {
+    def toInternal(x: Double) = x
+    def toExternal(x: Double) = x
+    override def isIdentity = true
+  }
+
   case class LinearConvert(name: String, one: Double, dDim: Int, tDim: Int, aDim: Int) extends Convert {
     import LinearConvert._
     def toInternal(x: Double) = x * one
     def toExternal(x: Double) = x / one
+    override def isIdentity = math.abs(one - 1) < 1e-9
 
     override def changeToInternal(ds: Array[Double]) { 
       if (math.abs(one-1) > 1e-9) { var i = 0; while (i < ds.length) { ds(i) = ds(i) * one; i +=1 } }
@@ -66,7 +74,7 @@ package units {
     val one = LinearConvert("", 1, 0, 0, 0)
     def scalar(x: Double) = LinearConvert(x.toString, x, 0, 0, 0)
     val percent = LinearConvert("%", 0.01, 0, 0, 0)
-    val celsius = new Convert { def name = "C"; def toInternal(x: Double) = x; def toExternal(x: Double) = x }
+    val celsius = IdentityConvert("C")
     val kelvin = new Convert { def name = "K"; def toInternal(x: Double) = x - 273.15; def toExternal(x: Double) = x + 273.15 }
     val fahrenheit = new Convert { def name = "F"; def toInternal(x: Double) = ((x-32)*5)/9; def toExternal(x: Double) = (x*9)/5 + 32 }    
   }

--- a/src/scala/src/test/scala/TestWcon.scala
+++ b/src/scala/src/test/scala/TestWcon.scala
@@ -10,6 +10,7 @@ import org.junit.Assert._
 
 class TestWcon {
   private val Accuracy = 1.001e-3
+  private def sigfig(x: Double) = org.openworm.trackercommons.Data.sig(x)
 
   def same(a: Json.Bool, b: Json.Bool, where: String): String =
     if (a.value == b.value) ""
@@ -227,23 +228,19 @@ class TestWcon {
 
   def same(a: UnitMap, b: UnitMap): String = same(a.json, b.json, "unitmap")
 
-  def same(a: Datum, b: Datum, where: String): String = same(
-    Data(a.nid, a.sid, Array(a.t), Array(a.x), Array(a.y), Array(a.cx), Array(a.cy), Array(a.ox), Array(a.oy), a.custom),
-    Data(b.nid, b.sid, Array(b.t), Array(b.x), Array(b.y), Array(b.cx), Array(b.cy), Array(a.ox), Array(a.oy), b.custom),
-    where
-  )
+  def same(a: Datum, b: Datum, where: String): String = same(a.toData, b.toData, where)
 
   def same(a: Data, b: Data, where: String): String =
     same(a.idJSON, b.idJSON, where + ".id") +
     same(Json.Arr.Dbl(a.ts), Json.Arr.Dbl(b.ts), where + ".ts") +
     same(
-      Json.Arr.All((0 until a.xs.length).map(i => Json.Arr.Dbl(a.gxs(i))).toArray), 
-      Json.Arr.All((0 until b.xs.length).map(i => Json.Arr.Dbl(b.gxs(i))).toArray), 
+      Json.Arr.All((0 until a.xDatas.length).map(i => Json.Arr.Dbl(a.spinePoints(i)._1)).toArray), 
+      Json.Arr.All((0 until b.xDatas.length).map(i => Json.Arr.Dbl(b.spinePoints(i)._1)).toArray), 
       where + ".xs"
     ) +
     same(
-      Json.Arr.All((0 until a.ys.length).map(i => Json.Arr.Dbl(a.gys(i))).toArray), 
-      Json.Arr.All((0 until b.ys.length).map(i => Json.Arr.Dbl(b.gys(i))).toArray), 
+      Json.Arr.All((0 until a.yDatas.length).map(i => Json.Arr.Dbl(a.spinePoints(i)._2)).toArray), 
+      Json.Arr.All((0 until b.yDatas.length).map(i => Json.Arr.Dbl(b.spinePoints(i)._2)).toArray), 
       where + ".ys"
     ) +
     same(Json.Arr.Dbl(a.cxs), Json.Arr.Dbl(b.cxs), where + ".cxs") +
@@ -256,34 +253,11 @@ class TestWcon {
       for (i <- a.indices) {
         val w = " data["+i+"]"
         val s = (a(i), b(i)) match {
-          case (Left(am), Left(bm)) => same(am, bm, w)
-          case (Left(am), Right(ba)) if ba.ts.length == 1 =>
-            same(
-              am,
-              Datum(
-                ba.nid, ba.sid, ba.ts(0), ba.xs(0), ba.ys(0),
-                if (ba.cxs.length > 0) ba.cxs(0) else Double.NaN,
-                if (ba.cys.length > 0) ba.cys(0) else Double.NaN,
-                if (ba.oxs.length > 0) ba.oxs(0) else Double.NaN,
-                if (ba.oys.length > 0) ba.oys(0) else Double.NaN,
-                ba.custom
-              ),
-              w
-            )
-          case (Right(aa), Left(bm)) if aa.ts.length == 1 => 
-            same(
-              Datum(
-                aa.nid, aa.sid, aa.ts(0), aa.xs(0), aa.ys(0),
-                if (aa.cxs.length > 0) aa.cxs(0) else Double.NaN,
-                if (aa.cys.length > 0) aa.cys(0) else Double.NaN,
-                if (aa.oxs.length > 0) aa.oxs(0) else Double.NaN,
-                if (aa.oys.length > 0) aa.oys(0) else Double.NaN,
-                aa.custom
-              ),
-              bm,
-              w
-            )
-          case (Right(aa), Right(ba)) => same(aa, ba, w)
+          case (Left(am), Left(bm))                       => same(am, bm, w)
+          case (Left(am), Right(ba)) if ba.ts.length == 1 => same(am.toData, ba, w)
+          case (Right(aa), Left(bm)) if aa.ts.length == 1 => same(aa, bm.toData, w)
+          case (Right(aa), Right(ba))                     => same(aa, ba, w)
+          case _                                          => w + f" unequal lengths at $i (singleton vs. array)"
         }
         if (s.nonEmpty) return s
       }
@@ -307,7 +281,7 @@ class TestWcon {
     case 0 => Double.PositiveInfinity
     case 1 => Double.NegativeInfinity
     case 2 | 3 => Double.NaN
-    case _ => 10*(r.nextDouble - 0.3)
+    case _ => 10*sigfig(r.nextDouble - 0.3)
   }
 
   def genANumJ(r: R): Json.Arr.Dbl = Json.Arr.Dbl((0 to r.nextInt(30)).map(_ => genDbl(r)).toArray)
@@ -351,7 +325,7 @@ class TestWcon {
     case 1 => Json.Bool(r.nextBoolean)
     case 2 => Json.Str(genFish(r))
     case 3 => Json.Num(r.nextInt(5) match { case 0 => Double.PositiveInfinity; case 1 => Double.NegativeInfinity; case _ => Double.NaN })
-    case 4 => Json.Num(r.nextDouble - 0.5)
+    case 4 => Json.Num(sigfig(r.nextDouble - 0.5))
     case 5 => genANumJ(r)
     case 6 => genAANumJ(r)
     case 7 => genArrJ(r, depth + 1, allowDuplicates)
@@ -386,7 +360,7 @@ class TestWcon {
       }
     })
 
-  def genTemp(r: R): Double = 273.15 + 33*r.nextDouble
+  def genTemp(r: R): Double = 273.15 + 33*sigfig(r.nextDouble)
 
   def genArena(r: R): Arena = Iterator.continually{
     Arena(
@@ -416,7 +390,7 @@ class TestWcon {
     Vector.fill(r.nextInt(3))(genFish(r)),
     opt(r)(genLDT(r)),
     opt(r)(genTemp(r)),
-    opt(r)(r.nextDouble),
+    opt(r)(sigfig(r.nextDouble)),
     opt(r)(genArena(r)),
     opt(r)(genFish(r)),
     opt(r)(genFish(r)),
@@ -432,7 +406,7 @@ class TestWcon {
 
   def genUnitMap(r: R, md: Metadata): UnitMap = {
     val dur = r.nextInt(6) match { case 0 => "ms"; case 1 => "h"; case 2 => "min"; case _ => "s" }
-    val dist = r.nextInt(6) match { case 0 => "cm"; case 1 => "um"; case 2 => "inch"; case _ => "mm" }
+    val dist = (3+r.nextInt(6)) match { case 0 => "cm"; case 1 => "um"; case 2 => "inch"; case _ => "mm" }
     val namedUnits = Array("mm", "cm", "meter", "metre", "K", "C", "F", "mm^2/s", "1/hr", "1 / ms cm").map(units.parseUnit).map(_.get)
     var m = Map(
       "t" -> units.parseUnit(dur).get,
@@ -454,36 +428,42 @@ class TestWcon {
     UnitMap(m, Json.Obj.empty)
   }
 
-  def genDatum(r: R): Datum = genData(r) match {
-    case Data(nid, sid, ts, xs, ys, cxs, cys, oxs, oys, custom) => Datum(nid, sid, ts(0), xs(0), ys(0), cxs.headOption.getOrElse(Double.NaN), cys.headOption.getOrElse(Double.NaN), oxs.headOption.getOrElse(Double.NaN), cys.headOption.getOrElse(Double.NaN), custom)
-  }
+  def genDatum(r: R): Datum = genData(r).datum(0)
 
   def genData(r: R): Data = {
     val (nid, sid) = r.nextInt(4) match {
-      case 0 => (r.nextDouble, null)
+      case 0 => (sigfig(r.nextDouble), null)
       case 1 => (r.nextInt(100).toDouble, null)
       case _ => (Double.NaN, "worm-"+r.nextInt(1000))
     }
-    val ts = Array.fill(r.nextInt(10)+1)(0.1 + 0.9*r.nextDouble) match { case x => var i = 1; while (i < x.length) { x(i) = x(i) + x(i-1); i += 1 }; x }
+    val ts = Array.fill(r.nextInt(10)+1)(0.1 + 0.9*r.nextDouble) match { case x =>
+      x(0) = sigfig(x(0)); var i = 1; while (i < x.length) { x(i) = sigfig(x(i) + x(i-1)); i += 1 }; x
+    }
     val (cxs, cys) = 
       if (r.nextInt(5) == 0) (Data.emptyD, Data.emptyD)
       else {
-        val a, b = Array.fill(ts.length)(r.nextDouble - 0.5) match { case x => var i = 1; while (i < x.length) { x(i) = x(i) + x(i-1); i += 1 }; x }
+        val a, b = Array.fill(ts.length)(r.nextDouble - 0.5) match { case x => 
+          x(0) = sigfig(x(0)); var i = 1; while (i < x.length) { x(i) = sigfig(x(i) + x(i-1)); i += 1 }; x 
+        }
         (a, b)
       }
     val (oxs, oys) = r.nextInt(5) match {
       case 0 => (Data.emptyD, Data.emptyD)
-      case 1 => val a, b = Array(100*(r.nextDouble - 0.5)); (a, b)
-      case _ => val a, b = Array.fill(ts.length)(100*(r.nextDouble - 0.5)); (a, b)
+      case 1 => val a, b = Array(sigfig(100*(r.nextDouble - 0.5))); (a, b)
+      case _ => val a, b = Array.fill(ts.length)(sigfig(100*(r.nextDouble - 0.5))); (a, b)
     }
     val xsb, ysb = Array.newBuilder[Array[Float]]
     (0 until ts.length).foreach{ _ =>
       val n = r.nextInt(11)+1
-      val x, y = Array.fill(n)((r.nextDouble - 0.5).toFloat).sorted
+      val x, y = Array.fill(n)(sigfig(r.nextDouble - 0.5).toFloat).sorted
       xsb += x
       ysb += y
     }
-    Data(nid, sid, ts, xsb.result, ysb.result, cxs, cys, oxs, oys, genCustom(r))
+    Data(
+      nid, sid, ts, xsb.result, ysb.result, cxs, cys, oxs, oys, false, None, None, genCustom(r)
+    )(
+      new Array[Double](ts.length), new Array[Double](ts.length)
+    )
   }
 
   def genDataA(r: R): Array[Either[Datum, Data]] = {
@@ -523,7 +503,8 @@ class TestWcon {
           println(ser)
           println("###############################")
           println(des.json)
-          println(x) 
+          println(x)
+          println
           x
         case x => x
       })      
@@ -539,7 +520,7 @@ class TestWcon {
       val dss = wc.toUnderlying
       val Seq(dsnd, dssnd) =
         Seq(ds, dss).map(dx => dx.copy(data = dx.data.map{ d => 
-          val c = d.fold(_.custom, _.custom); Right[Datum, Data](Data.empty.copy(custom = c)) 
+          val c = d.fold(_.custom, _.custom); Right[Datum, Data](Data.empty.copy(custom = c)(Data.empty.rxs, Data.empty.rys)) 
         }))
       assertEquals(
         "", 
@@ -604,7 +585,7 @@ class TestWcon {
 
     val wcons: Array[DataSet] = (jsons.map(_.to(DataSet)) zip paths).map{
       case (Left(je), p) => println(je); println(p); fail("Error reading WCON data from JSON"); throw new Exception("Never here")
-      case (Right(j), _) => j
+      case (Right(ds), p) => ds.withSourceFile(p)
     }
 
     assertTrue("All coordinates not the same", {
@@ -613,11 +594,22 @@ class TestWcon {
         w.data.indices.forall{ i =>
           val wi = w.data(i)
           val vi = v.data(i)
-          (wi, vi) match {
+          val ans = (wi, vi) match {
             case (Left(wd), Left(vd)) => wd.similarTo(vd, 1e-4, wd.cx.finite && vd.cx.finite)
             case (Right(wd), Right(vd)) => wd.similarTo(vd, 1e-4, wd.cxs.length > 0 && vd.cxs.length > 0)
             case _ => fail("Data/datum mismatch"); false
           }
+          if (!ans) {
+            println( "Failed coordinate match!")
+            println(f"Mismatch at data index $i; note rxs/rys")
+            println(f"In ${w.sourceFile.map(_.getName).getOrElse("?")}:")            
+            println(f"  ${wi match { case Right(d) => d.rxs.mkString(", "); case Left(dm) => dm.rx.toString } }")
+            println(f"  ${wi match { case Right(d) => d.rys.mkString(", "); case Left(dm) => dm.ry.toString } }")
+            println(f"In ${v.sourceFile.map(_.getName).getOrElse("?")}:")
+            println(f"  ${vi match { case Right(d) => d.rxs.mkString(", "); case Left(dm) => dm.rx.toString } }")
+            println(f"  ${vi match { case Right(d) => d.rys.mkString(", "); case Left(dm) => dm.ry.toString } }")
+          }
+          ans
         }
       }))
     })

--- a/tests/offset_and_centroid.wcon
+++ b/tests/offset_and_centroid.wcon
@@ -3,13 +3,13 @@
     "data":[
         {
             "id":1, "t":0, "cx":5, "cy":4, "ox":2, "oy":4,
-            "x":[-0.5, 0, 0.5], "y":[0.3, 0, -0.4]
+            "x":[4.5, 5, 5.5], "y":[4.3, 4, 3.6]
 	},
         {
             "id":2, "t":[0, 0.1],
             "cx":[3, 3.1], "cy":[3, 2.9], "ox":[4, 4], "oy":[3, 3],
-            "x":[[-0.5, 0.5], [-0.5, 0.4]],
-            "y":[[0.4, -0.3], [0.3, -0.4]]
+            "x":[[2.5, 3.5], [2.6, 3.5]],
+            "y":[[3.4, 2.7], [3.2, 2.5]]
         }
     ],
     "comment":"All four .wcon test files starting with 'offset_' should represent the same spine points.  Additionally, if there are centroids they should match.",

--- a/tests/offset_no_centroid_yes.wcon
+++ b/tests/offset_no_centroid_yes.wcon
@@ -2,13 +2,13 @@
     "units":{ "t":"s", "x":"mm", "y":"mm", "cx":"mm", "cy":"mm" },
     "data":[
         { "id":1, "t":0, "cx":7, "cy":8,
-            "x":[-0.5, 0, 0.5], "y":[0.3, 0, -0.4]
+            "x":[6.5, 7, 7.5], "y":[8.3, 8, 7.6]
 	},
         {
             "id":2, "t":[0, 0.1],
             "cx":[7, 7.1], "cy":[6, 5.9],
-            "x":[[-0.5, 0.5], [-0.5, 0.4]],
-            "y":[[0.4, -0.3], [0.3, -0.4]]
+            "x":[[6.5, 7.5], [6.6, 7.5]],
+            "y":[[6.4, 5.7], [6.2, 5.5]]
         }
     ],
     "comment":"All four .wcon test files starting with 'offset_' should represent the same spine points.  Additionally, if there are centroids they should match.",

--- a/tests/perimeter_points.wcon
+++ b/tests/perimeter_points.wcon
@@ -1,0 +1,25 @@
+{
+    "units":{
+        "t":"s", "x":"mm", "y":"mm",
+        "ox":"mm", "oy":"mm", "px":"mm", "py":"mm"
+    },
+    "data":[
+        {
+            "id":1, "t":0, "ox":2, "oy":4,
+            "x":[4.5, 5, 5.5], "y":[4.3, 4, 3.6],
+            "px":[4.5, 4.8, 5.2, 5.5, 5.3, 4.7],
+            "py":[4.3, 4.2, 3.9, 3.6, 3.7, 4.1],
+            "ptail":3
+	},
+        {
+            "id":2, "t":[0, 0.1],
+            "ox":[4, 4], "oy":[3, 3],
+            "x":[[2.5, 3.5], [2.6, 3.5]],
+            "y":[[3.4, 2.7], [3.2, 2.5]],
+            "px":[[2.5, 2.6, 3.5, 3.4], [2.6, 2.7, 3.5, 3.3]],
+            "py":[[3.4, 3.3, 2.7, 2.8], [3.2, 2.9, 2.5, 2.7]]
+        }
+    ],
+    "comment":"Perimeter points px and py are an optional feature understood by some WCON readers!",
+    "note":"Neither 'comment' nor 'note' are understood by WCON.  They, and other unspecified tags, should be ignored by readers."
+}


### PR DESCRIPTION
Added perimeters to the Scala implementation, both PerimeterPoints (which is just a list of perimeter
points), and PixelWalk (which traces the outline of the animal in a compressed 4-connected contour).

Simultaneously dropped double-origin scheme where either origin or centroid could serve; now everything is relative to origin only. (Writing the perimeter code highlighted that the double-origin scheme was a significant hassle.)

Original origin scheme could be reinstated now that it's working in the simpler way.